### PR TITLE
Fix from the source made by Coruja resolving the following problem:

### DIFF
--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -1562,7 +1562,7 @@ public:
      *
      * @return  The calculated combat chance to hit.
      */
-	int Calc_CombatChanceToHit( CChar * pChar, CChar * pCharTarg, SKILL_TYPE skill );
+	int Calc_CombatChanceToHit( CChar * pChar, CChar * pCharTarg);
 
     /**
      * @fn  int CServerConfig::Calc_StealingItem( CChar * pCharThief, CItem * pItem, CChar * pCharMark );

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -941,11 +941,11 @@ private:
 	// Armor, weapons and combat ------------------------------------
 	int	CalcFightRange( CItem * pWeapon = NULL );
 
-	SKILL_TYPE Fight_GetWeaponSkill() const;
+	
 	bool Fight_IsActive() const;
 public:
 	int CalcArmorDefense() const;
-
+	
 	void Memory_Fight_Retreat( CChar * pTarg, CItemMemory * pFight );
 	void Memory_Fight_Start( const CChar * pTarg );
 	bool Memory_Fight_OnTick( CItemMemory * pMemory );
@@ -957,6 +957,7 @@ public:
 	WAR_SWING_TYPE Fight_Hit( CChar * pCharTarg );
 	bool Fight_Parry(CItem * &pItemParry);
 	WAR_SWING_TYPE Fight_CanHit(CChar * pCharTarg);
+	SKILL_TYPE Fight_GetWeaponSkill() const;
 	int Fight_CalcDamage( const CItem * pWeapon, bool bNoRandom = false, bool bGetMax = true ) const;
 	bool Fight_IsAttackable();
 

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -2684,7 +2684,7 @@ int CChar::Skill_Fighting( SKTRIG_TYPE stage )
 			iRemainingDelay = 0;
 
 		SetTimeout(iRemainingDelay);
-		return g_Cfg.Calc_CombatChanceToHit(this, m_Fight_Targ_UID.CharFind(), Skill_GetActive());	// How difficult? 1-10000
+		return g_Cfg.Calc_CombatChanceToHit(this, m_Fight_Targ_UID.CharFind());	// How difficult? 1-10000
 	}
 
 	if ( stage == SKTRIG_STROKE )


### PR DESCRIPTION
 Fixed: Combat Hit Chance formulas incorrectly assuming that defenders always using the same combat skill as the attacker
See:
https://github.com/Sphereserver/Source/commit/0341418513bfcf7cbe60b017b31d283c5167ab9c
And:
https://github.com/Sphereserver/Source/issues/88