### PR TITLE
Fix from the Source1 by Coruja regarding Spellbook crash:

### DIFF
--- a/src/game/clients/CClientMsg.cpp
+++ b/src/game/clients/CClientMsg.cpp
@@ -2091,7 +2091,7 @@ void CClient::addSpellbookOpen( CItem * pBook )
 	int count = pBook->GetSpellcountInBook();
 	if ( count == -1 )
 		return;
-
+	addItem(pBook);
 	OpenPacketTransaction transaction(this, PacketSend::PRI_NORMAL);
 	addOpenGump( pBook, GUMP_OPEN_SPELLBOOK );
 


### PR DESCRIPTION
Fixed: Client 'Open Spellbook' macro making the client crash if it try to open the requested spellbook gump when the spellbook item is not loaded yet.
See:
https://github.com/Sphereserver/Source/commit/4f9214e963a79923fc34a136426261452641b580#diff-531c2f5f76724a94a0e6fa5f3cd2f318R2025

and:
https://github.com/Sphereserver/Source/issues/115