### PR TITLE
Ported 2 fixes from Source: combat hit chance formulas and client 'Op…

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -223,3 +223,10 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 - Fixed: ACTARG1/2/3 weren't zeroed at skill success, abort or failure if the SKF_SCRIPTED was set.
 - [Port from Source, 13-02-2017, Coruja] Changed: Spellbooks now store spell offset / max spells using TDATA3/TDATA4 instead MOREZ/MOREX.
 - [Port from Source, 21-04-2017, Coruja] Changed: Mount memories now can have their own i_mt_* ITEMDEFs instead use DEFNAME=i_mt_* directly on base items (usually 'boat parts').
+
+23-10-2017, Drk84
+- [Port from Source, 14-02-2017, Coruja] Fixed: Combat Hit Chance formulas incorrectly assuming that defender is always using the same combat skill as the attacker.
+  
+24-10-2017, Drk84 
+- [Port from Source, 19-09-2017, Coruja] Fixed: Client 'Open Spellbook' macro making the client crash if it try to open the requested spellbook gump when the spellbook item is not loaded yet.
+  

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -1562,7 +1562,7 @@ public:
      *
      * @return  The calculated combat chance to hit.
      */
-	int Calc_CombatChanceToHit( CChar * pChar, CChar * pCharTarg, SKILL_TYPE skill );
+	int Calc_CombatChanceToHit( CChar * pChar, CChar * pCharTarg);
 
     /**
      * @fn  int CServerConfig::Calc_StealingItem( CChar * pCharThief, CItem * pItem, CChar * pCharMark );

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -941,11 +941,11 @@ private:
 	// Armor, weapons and combat ------------------------------------
 	int	CalcFightRange( CItem * pWeapon = NULL );
 
-	SKILL_TYPE Fight_GetWeaponSkill() const;
+	
 	bool Fight_IsActive() const;
 public:
 	int CalcArmorDefense() const;
-
+	
 	void Memory_Fight_Retreat( CChar * pTarg, CItemMemory * pFight );
 	void Memory_Fight_Start( const CChar * pTarg );
 	bool Memory_Fight_OnTick( CItemMemory * pMemory );
@@ -957,6 +957,7 @@ public:
 	WAR_SWING_TYPE Fight_Hit( CChar * pCharTarg );
 	bool Fight_Parry(CItem * &pItemParry);
 	WAR_SWING_TYPE Fight_CanHit(CChar * pCharTarg);
+	SKILL_TYPE Fight_GetWeaponSkill() const;
 	int Fight_CalcDamage( const CItem * pWeapon, bool bNoRandom = false, bool bGetMax = true ) const;
 	bool Fight_IsAttackable();
 

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -2684,7 +2684,7 @@ int CChar::Skill_Fighting( SKTRIG_TYPE stage )
 			iRemainingDelay = 0;
 
 		SetTimeout(iRemainingDelay);
-		return g_Cfg.Calc_CombatChanceToHit(this, m_Fight_Targ_UID.CharFind(), Skill_GetActive());	// How difficult? 1-10000
+		return g_Cfg.Calc_CombatChanceToHit(this, m_Fight_Targ_UID.CharFind());	// How difficult? 1-10000
 	}
 
 	if ( stage == SKTRIG_STROKE )

--- a/src/game/clients/CClientMsg.cpp
+++ b/src/game/clients/CClientMsg.cpp
@@ -2091,7 +2091,7 @@ void CClient::addSpellbookOpen( CItem * pBook )
 	int count = pBook->GetSpellcountInBook();
 	if ( count == -1 )
 		return;
-
+	addItem(pBook);
 	OpenPacketTransaction transaction(this, PacketSend::PRI_NORMAL);
 	addOpenGump( pBook, GUMP_OPEN_SPELLBOOK );
 


### PR DESCRIPTION
…en Spellbook' macro.

* Fix from the source made by Coruja resolving the following problem:
 Fixed: Combat Hit Chance formulas incorrectly assuming that defenders always using the same combat skill as the attacker
See:
https://github.com/Sphereserver/Source/commit/0341418513bfcf7cbe60b017b31d283c5167ab9c
And:
https://github.com/Sphereserver/Source/issues/88

* Fix from the Source1 by Coruja regarding Spellbook crash:
Fixed: Client 'Open Spellbook' macro making the client crash if it try to open the requested spellbook gump when the spellbook item is not loaded yet.
See:
https://github.com/Sphereserver/Source/commit/4f9214e963a79923fc34a136426261452641b580#diff-531c2f5f76724a94a0e6fa5f3cd2f318R2025

and:
https://github.com/Sphereserver/Source/issues/115

* Updated Changelog

* Updated Changelog