### PR TITLE
- Fixed: using ADDCIRCLE without the second argument caused sphere to…

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -229,4 +229,6 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
   
 24-10-2017, Drk84 
 - [Port from Source, 19-09-2017, Coruja] Fixed: Client 'Open Spellbook' macro making the client crash if it try to open the requested spellbook gump when the spellbook item is not loaded yet.
-  
+
+24-10-2017, Nolok
+- Fixed: using ADDCIRCLE without the second argument caused sphere to crash. Also, its use on non t_spellbook items was incorrectly allowed.

--- a/src/game/CBase.cpp
+++ b/src/game/CBase.cpp
@@ -496,13 +496,9 @@ bool CBaseBaseDef::r_LoadVal( CScript & s )
 				size_t iQty = Str_ParseCmds( s.GetArgStr(), piVal, CountOf(piVal));
 				m_defenseBase = (uchar)(piVal[0]);
 				if ( iQty > 1 )
-				{
 					m_defenseRange = (uchar)(piVal[1]) - m_defenseBase;
-				}
 				else
-				{
 					m_defenseRange = 0;
-				}
 			}
 			return true;
 		case OBC_DAM:
@@ -511,13 +507,9 @@ bool CBaseBaseDef::r_LoadVal( CScript & s )
 				size_t iQty = Str_ParseCmds( s.GetArgStr(), piVal, CountOf(piVal));
 				m_attackBase = (uchar)(piVal[0]);
 				if ( iQty > 1 )
-				{
 					m_attackRange = (uchar)(piVal[1]) - m_attackBase;
-				}
 				else
-				{
 					m_attackRange = 0;
-				}
 			}
 			return true;
 		case OBC_BASEID:

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -2760,22 +2760,26 @@ bool CItem::r_LoadVal( CScript & s ) // Load an item Script
 			break;
 		case IC_ADDCIRCLE:
 			{
-				tchar	*ppVal[2];
+				if (m_type != IT_SPELLBOOK)
+				{
+					g_Log.EventError("ADDCIRCLE works only on t_spellbook items (mage spellbook).\n");
+					return false;
+				}
+
+				tchar *ppVal[2];
 				size_t amount = Str_ParseCmds(s.GetArgStr(), ppVal, CountOf(ppVal), " ,\t");
-				bool includeLower = 0;
+				bool includeLower = 0;	// should i add also the lower circles?
 				int addCircle = 0;
 
 				if ( amount <= 0 )
 					return false;
-				else
+				else if (amount > 1)
 					includeLower = (ATOI(ppVal[1]) != 0);
 
-				for ( addCircle = ATOI(ppVal[0]); addCircle; addCircle-- )
+				for ( addCircle = ATOI(ppVal[0]); addCircle; --addCircle )
 				{
 					for ( int i = 1; i < 9; ++i )
-					{
 						AddSpellbookSpell(static_cast<SPELL_TYPE>(RES_GET_INDEX(((addCircle - 1) * 8) + i)), false);
-					}
 
 					if ( includeLower == false )
 						break;
@@ -2876,12 +2880,10 @@ bool CItem::r_LoadVal( CScript & s ) // Load an item Script
 			if ( !IsTypeArmorWeapon() )
 			{
 				DEBUG_ERR(("Item:Hitpoints assigned for non-weapon %s\n", GetResourceName()));
+				return false;
 			}
-			else
-			{
-				m_itArmor.m_Hits_Cur = m_itArmor.m_Hits_Max = (word)(s.GetArgVal());
-				UpdatePropertyFlag(AUTOTOOLTIP_FLAG_DURABILITY);
-			}
+			m_itArmor.m_Hits_Cur = m_itArmor.m_Hits_Max = (word)(s.GetArgVal());
+			UpdatePropertyFlag(AUTOTOOLTIP_FLAG_DURABILITY);
 			return true;
 		case IC_ID:
 		{

--- a/src/game/items/CItemBase.cpp
+++ b/src/game/items/CItemBase.cpp
@@ -76,24 +76,15 @@ CItemBase::CItemBase( ITEMID_TYPE id ) :
 	// Do some special processing for certain items.
 
 	if ( IsType(IT_CHAIR))
-	{
 		SetHeight( 0 ); // have no effective height if they don't block.
-	}
 	else
-	{
-		//CBaseBaseDef * pBaseBaseDef = dynamic_cast<CBaseBaseDef*>(this);
-		//pBaseBaseDef->SetHeight( GetItemHeightFlags( tiledata, m_Can ));
 		SetHeight( GetItemHeightFlags( tiledata, m_Can ));
-		//DEBUG_WARN(("GetItemHeightFlags( tiledata, m_Can )(%d),tiledata.m_height(%d),m_dwDispIndex(0%x),GetHeight()(%d),pBaseBaseDef->GetHeight()(%d)\n",GetItemHeightFlags( tiledata, m_Can ),tiledata.m_height,m_wDispIndex,GetHeight(),pBaseBaseDef->GetHeight()));
-	}
-	//DEBUG_ERR(("ID: 0%x; this (0x%x), m_dwFlags (0%x), tiledata.m_flags (0%x), tiledata.m_height (%d) GetHeight() (%d)\n",id,this,m_dwFlags,tiledata.m_flags,tiledata.m_height,GetHeight()));
 
 	GetItemSpecificFlags( tiledata, m_Can, m_type, id );
 
-	if ( tiledata.m_weight == 0xFF ||	// not movable.
-		( tiledata.m_flags & UFLAG1_WATER ))
+	if ( (tiledata.m_weight == 0xFF) ||			// not movable.
+		( tiledata.m_flags & UFLAG1_WATER ) )	// water can't be picked up.
 	{
-		// water can't be picked up.
 		m_weight = UINT16_MAX;
 	}
 	else


### PR DESCRIPTION
… crash. Also, its use on non t_spellbook items was incorrectly allowed.