### PR TITLE
Fixes for MODMAXWEIGHT, weight tooltips and MORE2 of corpses.

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -232,3 +232,8 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 
 24-10-2017, Nolok
 - Fixed: using ADDCIRCLE without the second argument caused sphere to crash. Also, its use on non t_spellbook items was incorrectly allowed.
+- Fixed: MODMAXWEIGHT of a new player or item was a random number instead of zero.
+- Fixed: corpse MORE2 held an invalid UID instead of the killer's.
+- [Port from Source, 15-10-2017, Coruja]
+	Fixed: MODMAXWEIGHT property not working correctly.
+	Changed: Updated 'weight' tooltip on containers.

--- a/src/game/CObjBase.cpp
+++ b/src/game/CObjBase.cpp
@@ -70,17 +70,18 @@ CObjBase::CObjBase( bool fItem )
 	m_iCreatedResScriptIdx = (size_t)-1;
 	m_iCreatedResScriptLine = -1;
 
-	m_wHue=HUE_DEFAULT;
+	m_wHue = HUE_DEFAULT;
 	m_timeout.Init();
 	m_timestamp.Init();
 
 	//	Init some global variables
 	m_fStatusUpdate = 0;
 	m_ModAr = 0;
+	m_ModMaxWeight = 0;
+	m_uidSpawnItem = UID_UNUSED;
 	m_PropertyList = NULL;
 	m_PropertyHash = 0;
 	m_PropertyRevision = 0;
-	m_uidSpawnItem = UID_UNUSED;
 
 	if ( g_Serv.IsLoading())
 	{
@@ -1818,7 +1819,7 @@ bool CObjBase::r_LoadVal( CScript & s )
 			m_Can = s.GetArgVal();
 			break;
 		case OC_MODMAXWEIGHT:
-			m_ModMaxWeight = static_cast<int>(s.GetArgVal());
+			m_ModMaxWeight = s.GetArgVal();
 			break;
 		case OC_COLOR:
 			if ( !strnicmp( s.GetArgStr(), "match_shirt", 11 ) || !strnicmp( s.GetArgStr(), "match_hair", 10 ))
@@ -1933,6 +1934,8 @@ void CObjBase::r_Write( CScript & s )
 		s.WriteKeyHex("SPAWNITEM", m_uidSpawnItem);
 	if ( m_ModAr )
 		s.WriteKeyVal("MODAR", m_ModAr);
+	if ( m_ModMaxWeight )
+		s.WriteKeyVal("MODMAXWEIGHT", m_ModMaxWeight);
 
 	// Write New variables
 	m_BaseDefs.r_WritePrefix(s);

--- a/src/game/CObjBase.h
+++ b/src/game/CObjBase.h
@@ -23,18 +23,18 @@ class PacketPropertyList;
 
 class CObjBase : public CObjBaseTemplate, public CScriptObj
 {
-	static lpctstr const sm_szLoadKeys[];   ///< All Instances of CItem or CChar have these base attributes.
-	static lpctstr const sm_szVerbKeys[];   ///< All Instances of CItem or CChar have these base attributes.
-	static lpctstr const sm_szRefKeys[];    ///< All Instances of CItem or CChar have these base attributes.
+	static lpctstr const sm_szLoadKeys[];   // All Instances of CItem or CChar have these base attributes.
+	static lpctstr const sm_szVerbKeys[];   // All Instances of CItem or CChar have these base attributes.
+	static lpctstr const sm_szRefKeys[];    // All Instances of CItem or CChar have these base attributes.
 
 private:
-	CServerTime m_timeout;		///< when does this rot away ? or other action. 0 = never, else system time
-	CServerTime m_timestamp;    ///< TimeStam
-	HUE_TYPE m_wHue;			///< Hue or skin color. (CItems must be < 0x4ff or so)
-	lpctstr m_RunningTrigger;   ///< Current trigger being run on this object. Used to prevent the same trigger being called over and over.
+	CServerTime m_timeout;		// when does this rot away ? or other action. 0 = never, else system time
+	CServerTime m_timestamp;    // TimeStam
+	HUE_TYPE m_wHue;			// Hue or skin color. (CItems must be < 0x4ff or so)
+	lpctstr m_RunningTrigger;   // Current trigger being run on this object. Used to prevent the same trigger being called over and over.
 
 protected:
-	CResourceRef m_BaseRef;     ///< Pointer to the resource that describes this type.
+	CResourceRef m_BaseRef;     // Pointer to the resource that describes this type.
 
 public:
 	static const char *m_sClassName;
@@ -42,20 +42,20 @@ public:
 	size_t m_iCreatedResScriptIdx;	// index in g_Cfg.m_ResourceFiles of the script file where this obj was created
 	int m_iCreatedResScriptLine;	// line in the script file where this obj was created
 
-	CVarDefMap m_TagDefs;		///< attach extra tags here.
-	CVarDefMap m_BaseDefs;		///< New Variable storage system
-	dword	m_Can;              ///< CAN_FLAGS
-	int m_ModMaxWeight;			///< ModMaxWeight prop for chars
+	CVarDefMap m_TagDefs;		// attach extra tags here.
+	CVarDefMap m_BaseDefs;		// New Variable storage system
+	dword	m_Can;              // CAN_FLAGS
 
-	word	m_attackBase;       ///< dam for weapons
-	word	m_attackRange;      ///< variable range of attack damage.
+	word	m_attackBase;       // dam for weapons
+	word	m_attackRange;      // variable range of attack damage.
 
-	word	m_defenseBase;	    ///< Armor for IsArmor items
-	word	m_defenseRange;     ///< variable range of defense.
-	CUID m_uidSpawnItem;		///< SpawnItem for this item
+	word	m_defenseBase;	    // Armor for IsArmor items
+	word	m_defenseRange;     // variable range of defense.
+	int 	m_ModMaxWeight;		// ModMaxWeight prop.
+	CUID 	m_uidSpawnItem;		// SpawnItem for this item
 
 	CResourceRefArray m_OEvents;
-	static size_t sm_iCount;    ///< how many total objects in the world ?
+	static size_t sm_iCount;    // how many total objects in the world ?
 
 	/**
 	* @fn  inline bool CObjBase::CallPersonalTrigger(tchar * pArgs, CTextConsole * pSrc, TRIGRET_TYPE & trResult, bool bFull);

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -3302,8 +3302,6 @@ void CChar::r_Write( CScript & s )
 	if ( m_level )
 		s.WriteKeyVal("LEVEL", m_level);
 
-	if ( m_ModMaxWeight )
-		s.WriteKeyVal("MODMAXWEIGHT", m_ModMaxWeight);
 	if ( m_height )
 		s.WriteKeyVal("HEIGHT", m_height);
 	if ( m_ptHome.IsValidPoint() )
@@ -3375,9 +3373,8 @@ bool CChar::r_Load( CScript & s ) // Load a character from script
 	CScriptObj::r_Load(s);
 
 	if (m_pNPC)
-	{
 		NPC_GetAllSpellbookSpells();
-	}
+
 	// Init the STATF_SaveParity flag.
 	// StatFlag_Mod( STATF_SaveParity, g_World.m_fSaveParity );
 

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -121,8 +121,7 @@ public:
 
 	height_t m_height;			// Height set in-game or under some trigger (height=) - for both items and chars
 
-	int m_ModMaxWeight;
-	CUID m_UIDLastNewItem;		///< Last item created, used to store on this CChar the UID of the last created item via ITEM or ITEMNEWBIe in @Create and @Restock to prevent COLOR, etc properties to be called with no reference when the item was not really created, ie: ITEM=i_dagger,R5
+	CUID m_UIDLastNewItem;		// Last item created, used to store on this CChar the UID of the last created item via ITEM or ITEMNEWBIe in @Create and @Restock to prevent COLOR, etc properties to be called with no reference when the item was not really created, ie: ITEM=i_dagger,R5
 	uint m_exp;					// character experience
 	uint m_level;				// character experience level
 	byte m_iVisualRange;		// Visual Range
@@ -131,7 +130,7 @@ public:
 	bool m_fIgnoreNextPetCmd;	// return 1 in speech block for this pet will make it ignore target petcmds while allowing the rest to perform them
 	height_t m_zClimbHeight;	// The height at the end of the climbable.
 
-								// Saved stuff.
+	// Saved stuff.
 	DIR_TYPE m_dirFace;			// facing this dir.
 	CSString m_sTitle;			// Special title such as "the guard" (replaces the normal skill title)
 	CPointMap m_ptHome;			// What is our "home" region. (towns and bounding of NPC's)
@@ -149,7 +148,7 @@ public:
 	bool IsTriggerActive(lpctstr trig) { return static_cast<CObjBase*>(const_cast<CChar*>(this))->IsTriggerActive(trig); }
 	void SetTriggerActive(lpctstr trig = NULL) { static_cast<CObjBase*>(const_cast<CChar*>(this))->SetTriggerActive(trig); }
 
-	// Client's local light
+	// Client's local light (might be useful in the future for NPCs also? keep it here for now)
 	byte m_LocalLight;
 
 	// When events happen to the char. check here for reaction scripts.
@@ -327,16 +326,14 @@ public:
 	int	 GetHealthPercent() const;
 	lpctstr GetTradeTitle() const; // Paperdoll title for character p (2)
 
-								   // Information about us.
+	// Information about us.
 	CREID_TYPE GetID() const;
 	word GetBaseID() const;
 	CREID_TYPE GetDispID() const;
 	void SetID( CREID_TYPE id );
 
 	lpctstr GetName() const;
-
 	lpctstr GetNameWithoutIncognito() const;
-
 	lpctstr GetName( bool fAllowAlt ) const;
 
 	bool SetName( lpctstr pName );

--- a/src/game/chars/CCharBase.cpp
+++ b/src/game/chars/CCharBase.cpp
@@ -27,14 +27,9 @@ CCharBase::CCharBase( CREID_TYPE id ) :
 	m_iMoveRate = (short)(g_Cfg.m_iMoveRate);
 
 	if ( IsValidDispID(id))
-	{
-		// in display range.
-		m_dwDispIndex = id;
-	}
+		m_dwDispIndex = id;	// in display range.
 	else
-	{
 		m_dwDispIndex = 0;	// must read from SCP file later
-	}
 
 	SetResDispDnId(CREID_MAN);
 }
@@ -46,16 +41,16 @@ lpctstr CCharBase::GetTradeName() const
 	ADDTOCALLSTACK("CCharBase::GetTradeName");
 	lpctstr pName = CBaseBaseDef::GetTypeName();
 	if ( pName[0] != '#' )
-		return( pName );
+		return pName;
 
 	lpctstr pSpace = strchr( pName, ' ' );
 	if ( pSpace == NULL )
-		return( pName );
+		return pName;
 
 	pSpace++;
 	if ( ! strnicmp( pSpace, "the ", 4 ))
 		pSpace += 4;
-	return( pSpace );
+	return pSpace;
 }
 
 void CCharBase::CopyBasic( const CCharBase * pCharDef )

--- a/src/game/chars/CCharact.cpp
+++ b/src/game/chars/CCharact.cpp
@@ -2815,7 +2815,6 @@ bool CChar::Death()
 	SetPoisonCure(0, true);
 	Skill_Cleanup();
 	Spell_Dispel(100);			// get rid of all spell effects (moved here to prevent double @Destroy trigger)
-	m_lastAttackers.clear();	// clear list of attackers
 
 	if ( m_pPlayer )		// if I'm NPC then my mount goes with me
 		Horse_UnMount();
@@ -2830,6 +2829,7 @@ bool CChar::Death()
 			OnTrigger(CTRIG_DeathCorpse, this, &Args);
 		}
 	}
+	m_lastAttackers.clear();	// clear list of attackers
 
 	// Play death animation (fall on ground)
 	UpdateCanSee(new PacketDeath(this, pCorpse), m_pClient);

--- a/src/game/clients/CClientMsg_AOSTooltip.cpp
+++ b/src/game/clients/CClientMsg_AOSTooltip.cpp
@@ -551,8 +551,24 @@ void CClient::AOSTooltip_addDefaultItemData(const CItem * pItem)
 		if (pItem->IsContainer())
 		{
 			const CContainer * pContainer = dynamic_cast <const CContainer *> (pItem);
-			this->m_TooltipData.Add(t = new CClientTooltip(1050044));
-			t->FormatArgs("%" PRIuSIZE_T "\t%d", pContainer->GetCount(), pContainer->GetTotalWeight() / WEIGHT_UNITS); // ~1_COUNT~ items, ~2_WEIGHT~ stones
+			if ( g_Cfg.m_iFeatureML & FEATURE_ML_UPDATE )
+			{
+				if ( pItem->m_ModMaxWeight )
+				{
+					m_TooltipData.Add(t = new CClientTooltip(1072241)); // Contents: ~1_COUNT~/~2_MAXCOUNT~ items, ~3_WEIGHT~/~4_MAXWEIGHT~ stones
+					t->FormatArgs("%" PRIuSIZE_T "\t%d\t%d\t%d", pContainer->GetCount(), MAX_ITEMS_CONT, pContainer->GetTotalWeight() / WEIGHT_UNITS, pItem->m_ModMaxWeight / WEIGHT_UNITS);
+				}
+				else
+				{
+					m_TooltipData.Add(t = new CClientTooltip(1073841)); // Contents: ~1_COUNT~/~2_MAXCOUNT~ items, ~3_WEIGHT~ stones
+					t->FormatArgs("%" PRIuSIZE_T "\t%d\t%d", pContainer->GetCount(), MAX_ITEMS_CONT, pContainer->GetTotalWeight() / WEIGHT_UNITS);
+				}
+			}
+			else
+			{
+				m_TooltipData.Add(t = new CClientTooltip(1050044));
+				t->FormatArgs("%" PRIuSIZE_T "\t%d", pContainer->GetCount(), pContainer->GetTotalWeight() / WEIGHT_UNITS); // ~1_COUNT~ items, ~2_WEIGHT~ stones
+			}
 		}
 		break;
 

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -3046,9 +3046,7 @@ bool CItem::r_Load( CScript & s ) // Load an item from script
 	if ( GetContainer() == NULL )	// Place into the world.
 	{
 		if ( GetTopPoint().IsCharValid())
-		{
 			MoveToUpdate( GetTopPoint());
-		}
 	}
 
 	int iResultCode = CObjBase::IsWeird();

--- a/src/game/items/CItemContainer.cpp
+++ b/src/game/items/CItemContainer.cpp
@@ -34,9 +34,7 @@ bool CItemContainer::NotifyDelete()
 void CItemContainer::DeletePrepare()
 {
 	if ( IsType( IT_EQ_TRADE_WINDOW ))
-	{
 		Trade_Delete();
-	}
 	CItem::DeletePrepare();
 }
 
@@ -59,9 +57,16 @@ bool CItemContainer::r_GetRef( lpctstr &pszKey, CScriptObj *&pRef )
 bool CItemContainer::r_WriteVal( lpctstr pszKey, CSString &sVal, CTextConsole *pSrc )
 {
 	ADDTOCALLSTACK("CItemContainer::r_WriteVal");
+	EXC_TRY("WriteVal");
 	if ( r_WriteValContainer(pszKey, sVal, pSrc) )
 		return true;
 	return CItemVendable::r_WriteVal(pszKey, sVal, pSrc);
+	EXC_CATCH;
+
+	EXC_DEBUG_START;
+	EXC_ADD_KEYRET(pSrc);
+	EXC_DEBUG_END;
+	return false;
 }
 
 bool CItemContainer::IsItemInTrade() const
@@ -724,7 +729,7 @@ bool CItemContainer::CanContainerHold( const CItem *pItem, const CChar *pCharMsg
 
 	if (m_ModMaxWeight)
 	{
-		if ((GetWeight(GetType() == IT_CORPSE ? 1 : 0) + pItem->GetWeight()) > (m_ModMaxWeight * WEIGHT_UNITS))
+		if ( GetTotalWeight() + pItem->GetWeight() > m_ModMaxWeight )
 		{
 			pCharMsg->SysMessageDefault(DEFMSG_CONT_FULL_WEIGHT);
 			return false;

--- a/src/game/items/CItemContainer.h
+++ b/src/game/items/CItemContainer.h
@@ -17,7 +17,9 @@ class CItemContainer : public CItemVendable, public CContainer
 	static lpctstr const sm_szVerbKeys[];
 public:
 	static const char *m_sClassName;
+
 	// bool m_fTinkerTrapped;	// magic trap is diff.
+
 	bool NotifyDelete();
 	void DeletePrepare();
 
@@ -41,7 +43,7 @@ public:
 	bool CanContainerHold(const CItem * pItem, const CChar * pCharMsg );
 
 	virtual bool r_Verb( CScript & s, CTextConsole * pSrc );
-	virtual void  r_Write( CScript & s );
+	virtual void r_Write( CScript & s );
 	virtual bool r_WriteVal( lpctstr pszKey, CSString & sVal, CTextConsole * pSrc );
 	virtual bool r_GetRef( lpctstr & pszKey, CScriptObj * & pRef );
 

--- a/src/game/items/CItemCorpse.cpp
+++ b/src/game/items/CItemCorpse.cpp
@@ -152,9 +152,9 @@ CItemCorpse * CChar::MakeCorpse( bool fFrontFall )
 	if ( !(wFlags & DEATH_NOLOOTDROP) )		// move non-newbie contents of the pack to corpse
 		DropAll( pCorpse );
 
-	pCorpse->m_ModMaxWeight = g_Cfg.Calc_MaxCarryWeight(this) / 10;		// set corpse maxweight to prevent weird exploits like when someone place many items on an player corpse just to make this player get stuck on resurrect
+	pCorpse->m_ModMaxWeight = g_Cfg.Calc_MaxCarryWeight(this);		// set corpse maxweight to prevent weird exploits like when someone place many items on an player corpse just to make this player get stuck on resurrect
 	pCorpse->MoveToDecay(GetTopPoint(), iDecayTimer);
-	return( pCorpse );
+	return pCorpse;
 }
 
 // We are creating a char from the current char and the corpse.

--- a/src/game/items/CItemVendable.cpp
+++ b/src/game/items/CItemVendable.cpp
@@ -92,15 +92,12 @@ void CItemVendable::r_Write(CScript &s)
 	ADDTOCALLSTACK_INTENSIVE("CItemVendable::r_Write");
 	CItem::r_Write(s);
 	if ( GetQuality() != 0 )
-	{
 		s.WriteKeyVal( "QUALITY", GetQuality());
-	}
 
 	// am i on a vendor right now ?
 	if ( m_price > 0 )
-	{
 		s.WriteKeyVal( "PRICE", m_price );
-	}
+
 	return;
 }
 

--- a/src/network/receive.cpp
+++ b/src/network/receive.cpp
@@ -155,7 +155,9 @@ bool PacketCreate::onReceive(NetState* net, bool hasExtraSkill)
 		startloc, 0, flags);
 }
 
-bool PacketCreate::doCreate(NetState* net, lpctstr charname, bool bFemale, RACE_TYPE rtRace, short wStr, short wDex, short wInt, PROFESSION_TYPE prProf, SKILL_TYPE skSkill1, int iSkillVal1, SKILL_TYPE skSkill2, int iSkillVal2, SKILL_TYPE skSkill3, int iSkillVal3, SKILL_TYPE skSkill4, int iSkillVal4, HUE_TYPE wSkinHue, ITEMID_TYPE idHair, HUE_TYPE wHairHue, ITEMID_TYPE idBeard, HUE_TYPE wBeardHue, HUE_TYPE wShirtHue, HUE_TYPE wPantsHue, int iStartLoc, int iPortrait, int iFlags)
+bool PacketCreate::doCreate(NetState* net, lpctstr charname, bool bFemale, RACE_TYPE rtRace, short wStr, short wDex, short wInt,
+	PROFESSION_TYPE prProf, SKILL_TYPE skSkill1, int iSkillVal1, SKILL_TYPE skSkill2, int iSkillVal2, SKILL_TYPE skSkill3, int iSkillVal3, SKILL_TYPE skSkill4, int iSkillVal4,
+	HUE_TYPE wSkinHue, ITEMID_TYPE idHair, HUE_TYPE wHairHue, ITEMID_TYPE idBeard, HUE_TYPE wBeardHue, HUE_TYPE wShirtHue, HUE_TYPE wPantsHue, int iStartLoc, int iPortrait, int iFlags)
 {
 	ADDTOCALLSTACK("PacketCreate::doCreate");
 

--- a/src/network/receive.h
+++ b/src/network/receive.h
@@ -44,7 +44,9 @@ public:
 
 protected:
 	bool onReceive(NetState* net, bool hasExtraSkill);
-	bool doCreate(NetState* net, lpctstr charname, bool bFemale, RACE_TYPE rtRace, short wStr, short wDex, short wInt, PROFESSION_TYPE prProf, SKILL_TYPE skSkill1, int iSkillVal1, SKILL_TYPE skSkill2, int iSkillVal2, SKILL_TYPE skSkill3, int iSkillVal3, SKILL_TYPE skSkill4, int iSkillVal4, HUE_TYPE wSkinHue, ITEMID_TYPE idHair, HUE_TYPE wHairHue, ITEMID_TYPE idBeard, HUE_TYPE wBeardHue, HUE_TYPE wShirtHue, HUE_TYPE wPantsHue, int iStartLoc, int iPortrait, int iFlags);
+	bool doCreate(NetState* net, lpctstr charname, bool bFemale, RACE_TYPE rtRace, short wStr, short wDex, short wInt, PROFESSION_TYPE prProf,
+		SKILL_TYPE skSkill1, int iSkillVal1, SKILL_TYPE skSkill2, int iSkillVal2, SKILL_TYPE skSkill3, int iSkillVal3, SKILL_TYPE skSkill4, int iSkillVal4,
+		HUE_TYPE wSkinHue, ITEMID_TYPE idHair, HUE_TYPE wHairHue, ITEMID_TYPE idBeard, HUE_TYPE wBeardHue, HUE_TYPE wShirtHue, HUE_TYPE wPantsHue, int iStartLoc, int iPortrait, int iFlags);
 };
 
 /***************************************************************************


### PR DESCRIPTION
- Fixed: MODMAXWEIGHT of a new player or item was a random number instead of zero.
- Fixed: corpse MORE2 held an invalid UID instead of the killer's.
- [Port from Source, 15-10-2017, Coruja]
	Fixed: MODMAXWEIGHT property not working correctly.
	Changed: Updated 'weight' tooltip on containers.