### PR TITLE
Big sound related fixes and more.

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -331,3 +331,12 @@ Note: More needs to be switched over and I am trying to get this and the Base Pa
 
 03-01-2018, Drk84
 - Added missing parenthesis to MulDivLL and MulDiv.
+
+03-01-2017, Nolok
+- Fixed: when playing a sound from a character from Samurai Empire and later expansions, it was chosen the wrong sound ID for the given action. This is caused by the different
+	order of IDs in the sound file after that expansion. Also, updated the script pack (sphere_defs.scp and sphere_monsters.scp) with a lot of new and corrected old sounds.
+	Still, some sounds are missing.
+- Fixed: some rare combat-related crashes.
+- Added: SOUNDTYPE_RAND, SOUNDTYPE_IDLE, SOUNDTYPE_NOTICE, SOUNDTYPE_HIT, SOUNDTYPE_GETHIT, SOUNDTYPE_DIE defs to the scripts. They are meant to be used with BARK,
+	which has always accepted as parameter the sound type (even if the wiki at this day doesn't say so), not the sound ID (use SOUND for this).
+- Updated: now when an NPC is looking around it can play different sounds depending on its AI choices. Also prevented human-sounding chars to play such noises.

--- a/src/common/CExpression.cpp
+++ b/src/common/CExpression.cpp
@@ -325,7 +325,7 @@ int64 Calc_GetRandLLVal2( int64 iMin, int64 iMax )
 {
 	if ( iMin > iMax )
 	{
-		int64 tmp = iMin;
+		llong tmp = iMin;
 		iMin = iMax;
 		iMax = tmp;
 	}
@@ -1049,7 +1049,7 @@ llong CExpression::GetVal( lpctstr & pExpr )
 	++g_getval_reentrant_check;
 	if ( g_getval_reentrant_check > 128 )
 	{
-		DEBUG_WARN(( "Deadlock detected while parsing '%s'. Fix the error in your scripts.\n", pExpr ));
+		g_Log.EventError( "Deadlock detected while parsing '%s'. Fix the error in your scripts.\n", pExpr );
 		--g_getval_reentrant_check;
 		return 0;
 	}

--- a/src/game/CObjBase.cpp
+++ b/src/game/CObjBase.cpp
@@ -2286,6 +2286,8 @@ bool CObjBase::r_Verb( CScript & s, CTextConsole * pSrc ) // Execute command fro
 				EXC_SET("SOUND");
 				int64 piCmd[2];
 				int iArgQty = Str_ParseCmds( s.GetArgStr(), piCmd, CountOf(piCmd));
+				if (!iArgQty)
+					return false;
 				Sound( static_cast<SOUND_TYPE>(piCmd[0]), ( iArgQty > 1 ) ? (int)(piCmd[1]) : 1 );
 			}
 			break;

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -1933,7 +1933,8 @@ bool CServerConfig::SetKRDialogMap(dword rid, dword idKRDialog)
 	}
 
 	// prevent double mapping of KR dialog
-	for (it = m_mapKRGumps.begin(); it != m_mapKRGumps.end(); ++it)
+	KRGumpsMap::iterator end = m_mapKRGumps.end();
+	for (it = m_mapKRGumps.begin(); it != end; ++it)
 	{
 		if (it->second != idKRDialog)
 			continue;

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -334,7 +334,6 @@ public:
 
 	int	 GetHealthPercent() const;
 	lpctstr GetTradeTitle() const; // Paperdoll title for character p (2)
-	SOUND_TYPE GetDefaultSound() const;
 
 	// Information about us.
 	CREID_TYPE GetID() const;
@@ -984,8 +983,9 @@ public:
 	}
 	bool	Attacker_Add(CChar * pChar, int64 threat = 0);
 	CChar * Attacker_GetLast();
-	bool	Attacker_Delete(CChar * pChar, bool bForced = false, ATTACKER_CLEAR_TYPE type = ATTACKER_CLEAR_FORCED);
 	bool	Attacker_Delete(size_t attackerIndex, bool bForced = false, ATTACKER_CLEAR_TYPE type = ATTACKER_CLEAR_FORCED);
+	bool	Attacker_Delete(std::vector<LastAttackers>::iterator &itAttacker, bool bForced, ATTACKER_CLEAR_TYPE type);
+	bool	Attacker_Delete(CChar * pChar, bool bForced = false, ATTACKER_CLEAR_TYPE type = ATTACKER_CLEAR_FORCED);
 	void	Attacker_RemoveChar();
 	void	Attacker_Clear();
 	void	Attacker_CheckTimeout();

--- a/src/game/chars/CCharAttacker.cpp
+++ b/src/game/chars/CCharAttacker.cpp
@@ -11,9 +11,9 @@ bool CChar::Attacker_Add( CChar * pChar, int64 threat )
 {
 	ADDTOCALLSTACK("CChar::Attacker_Add");
 	CUID uid = pChar->GetUID();
-	if ( m_lastAttackers.size() )	// Must only check for existing attackers if there are any attacker already.
+	if ( !m_lastAttackers.empty() )	// Must only check for existing attackers if there are any attacker already.
 	{
-		for ( auto it = m_lastAttackers.begin(); it != m_lastAttackers.end(); ++it )
+		for ( auto it = m_lastAttackers.begin(), end = m_lastAttackers.end(); it != end; ++it )
 		{
 			LastAttackers & refAttacker = *it;
 			if ( refAttacker.charUID == uid )
@@ -72,11 +72,11 @@ bool CChar::Attacker_Add( CChar * pChar, int64 threat )
 int64 CChar::Attacker_GetDam(size_t attackerIndex)
 {
 	ADDTOCALLSTACK("CChar::Attacker_GetDam");
-	if ( ! m_lastAttackers.size() )
+	if ( m_lastAttackers.empty() )
 		return -1;
 	if (  m_lastAttackers.size() <= attackerIndex )
 		return -1;
-	LastAttackers & refAttacker = m_lastAttackers.at(attackerIndex);
+	LastAttackers & refAttacker = m_lastAttackers[attackerIndex];
 	return refAttacker.amountDone;
 }
 
@@ -84,11 +84,11 @@ int64 CChar::Attacker_GetDam(size_t attackerIndex)
 int64 CChar::Attacker_GetElapsed(size_t attackerIndex)
 {
 	ADDTOCALLSTACK("CChar::Attacker_GetElapsed");
-	if ( ! m_lastAttackers.size() )
+	if ( m_lastAttackers.empty() )
 		return -1;
 	if ( m_lastAttackers.size() <= attackerIndex )
 		return -1;
-	LastAttackers & refAttacker = m_lastAttackers.at(attackerIndex);
+	LastAttackers & refAttacker = m_lastAttackers[attackerIndex];
 	return refAttacker.elapsed;
 }
 
@@ -96,23 +96,24 @@ int64 CChar::Attacker_GetElapsed(size_t attackerIndex)
 int64 CChar::Attacker_GetThreat(size_t attackerIndex)
 {
 	ADDTOCALLSTACK("CChar::Attacker_GetThreat");
-	if ( ! m_lastAttackers.size() )
+	if ( m_lastAttackers.empty() )
 		return -1;
 	if ( m_lastAttackers.size() <= attackerIndex )
 		return -1;
-	LastAttackers & refAttacker = m_lastAttackers.at(attackerIndex);
+	LastAttackers & refAttacker = m_lastAttackers[attackerIndex];
 	return refAttacker.threat ? refAttacker.threat : 0;
 }
 
 // Retrieves the character with most Threat
 int64 CChar::Attacker_GetHighestThreat()
 {
-	if ( !m_lastAttackers.size() )
+	if ( m_lastAttackers.empty() )
 		return -1;
+
 	int64 highThreat = 0;
-	for ( size_t count = 0; count < m_lastAttackers.size(); count++ )
+	for (auto it = m_lastAttackers.begin(), end = m_lastAttackers.end(); it != end; ++it)
 	{
-		LastAttackers & refAttacker = m_lastAttackers.at(count);
+		LastAttackers & refAttacker = *it;
 		if ( refAttacker.threat > highThreat )
 			highThreat = refAttacker.threat;
 	}
@@ -124,9 +125,9 @@ CChar * CChar::Attacker_GetLast()
 {
 	int64 dwLastTime = INT32_MAX, dwCurTime = 0;
 	CChar * retChar = NULL;
-	for (size_t iAttacker = 0; iAttacker < m_lastAttackers.size(); ++iAttacker)
+	for (auto it = m_lastAttackers.begin(), end = m_lastAttackers.end(); it != end; ++it)
 	{
-		LastAttackers & refAttacker = m_lastAttackers.at(iAttacker);
+		LastAttackers & refAttacker = *it;
 		dwCurTime = refAttacker.elapsed;
 		if (dwCurTime <= dwLastTime)
 		{
@@ -149,11 +150,11 @@ void CChar::Attacker_SetElapsed(CChar * pChar, int64 value)
 void CChar::Attacker_SetElapsed(size_t attackerIndex, int64 value)
 {
 	ADDTOCALLSTACK("CChar::Attacker_SetElapsed(size_t)");
-	if ( ! m_lastAttackers.size() )
+	if ( m_lastAttackers.empty() )
 		return;
 	if ( m_lastAttackers.size() <= attackerIndex )
 		return;
-	LastAttackers & refAttacker = m_lastAttackers.at(attackerIndex);
+	LastAttackers & refAttacker = m_lastAttackers[attackerIndex];
 	refAttacker.elapsed = value;
 }
 
@@ -164,16 +165,15 @@ void CChar::Attacker_SetDam( CChar * pChar, int64 value)
 	return Attacker_SetDam( Attacker_GetID(pChar), value );
 }
 
-
 // Damaged pChar
 void CChar::Attacker_SetDam(size_t attackerIndex, int64 value)
 {
 	ADDTOCALLSTACK("CChar::Attacker_SetDam(size_t)");
-	if ( ! m_lastAttackers.size() )
+	if ( m_lastAttackers.empty() )
 		return;
 	if ( m_lastAttackers.size() <= attackerIndex)
 		return;
-	LastAttackers & refAttacker = m_lastAttackers.at(attackerIndex);
+	LastAttackers & refAttacker = m_lastAttackers[attackerIndex];
 	refAttacker.amountDone = value;
 }
 
@@ -190,11 +190,11 @@ void CChar::Attacker_SetThreat(size_t attackerIndex, int64 value)
 	ADDTOCALLSTACK("CChar::Attacker_SetThreat(int)");
 	if (m_pPlayer)
 		return;
-	if (!m_lastAttackers.size())
+	if (m_lastAttackers.empty())
 		return;
 	if (m_lastAttackers.size() <= attackerIndex)
 		return;
-	LastAttackers & refAttacker = m_lastAttackers.at(attackerIndex);
+	LastAttackers & refAttacker = m_lastAttackers[attackerIndex];
 	refAttacker.threat = value;
 }
 
@@ -209,11 +209,11 @@ void CChar::Attacker_SetIgnore(CChar * pChar, bool fIgnore)
 void CChar::Attacker_SetIgnore(size_t attackerIndex, bool fIgnore)
 {
 	ADDTOCALLSTACK("CChar::Attacker_SetIgnore(int)");\
-	if (!m_lastAttackers.size())
+	if (m_lastAttackers.empty())
 		return;
 	if (m_lastAttackers.size() <= attackerIndex)
 		return;
-	LastAttackers & refAttacker = m_lastAttackers.at(attackerIndex);
+	LastAttackers & refAttacker = m_lastAttackers[attackerIndex];
 	refAttacker.ignore = fIgnore;
 }
 
@@ -228,11 +228,11 @@ bool CChar::Attacker_GetIgnore(CChar * pChar)
 bool CChar::Attacker_GetIgnore(size_t attackerIndex)
 {
 	ADDTOCALLSTACK("CChar::Attacker_GetIgnore(size_t)");
-	if (!m_lastAttackers.size())
+	if (m_lastAttackers.empty())
 		return false;
 	if (m_lastAttackers.size() <= attackerIndex)
 		return false;
-	LastAttackers & refAttacker = m_lastAttackers.at(attackerIndex);
+	LastAttackers & refAttacker = m_lastAttackers[attackerIndex];
 	return (refAttacker.ignore != 0);
 }
 
@@ -260,12 +260,12 @@ int CChar::Attacker_GetID( CChar * pChar )
 	ADDTOCALLSTACK("CChar::Attacker_GetID(CChar)");
 	if ( !pChar )
 		return -1;
-	if ( ! m_lastAttackers.size() )
+	if ( m_lastAttackers.empty() )
 		return -1;
 	int count = 0;
-	for ( auto it = m_lastAttackers.begin(); it != m_lastAttackers.end(); ++it )
+	for ( auto it = m_lastAttackers.begin(), end = m_lastAttackers.end(); it != end; ++it )
 	{
-		LastAttackers & refAttacker = m_lastAttackers.at(count);
+		LastAttackers & refAttacker = m_lastAttackers[count];
 		CUID uid = refAttacker.charUID;
 		if ( ! uid || !uid.CharFind() )
 			continue;
@@ -275,7 +275,7 @@ int CChar::Attacker_GetID( CChar * pChar )
 		if ( pMe == pChar )
 			return count;
 
-		count++;
+		++count;
 	}
 	return -1;
 }
@@ -291,11 +291,11 @@ int CChar::Attacker_GetID( CUID pChar )
 CChar * CChar::Attacker_GetUID(size_t attackerIndex)
 {
 	ADDTOCALLSTACK("CChar::Attacker_GetUID");
-	if ( ! m_lastAttackers.size() )
+	if ( m_lastAttackers.empty() )
 		return NULL;
 	if ( m_lastAttackers.size() <= attackerIndex)
 		return NULL;
-	LastAttackers & refAttacker = m_lastAttackers.at(attackerIndex);
+	LastAttackers & refAttacker = m_lastAttackers[attackerIndex];
 	CChar * pChar = static_cast<CChar*>( static_cast<CUID>( refAttacker.charUID ).CharFind() );
 	return pChar;
 }
@@ -304,9 +304,10 @@ CChar * CChar::Attacker_GetUID(size_t attackerIndex)
 bool CChar::Attacker_Delete(size_t attackerIndex, bool bForced, ATTACKER_CLEAR_TYPE type)
 {
 	ADDTOCALLSTACK("CChar::Attacker_Delete(size_t)");
-	if (!m_lastAttackers.size() || (m_lastAttackers.size() <= attackerIndex))
+	if (m_lastAttackers.empty() || (m_lastAttackers.size() <= attackerIndex))
 		return false;
-	LastAttackers &refAttacker = m_lastAttackers.at(attackerIndex);
+
+	LastAttackers &refAttacker = m_lastAttackers[attackerIndex];
 	CChar *pChar = static_cast<CUID>(refAttacker.charUID).CharFind();
 	if (!pChar)
 		return false;
@@ -320,16 +321,51 @@ bool CChar::Attacker_Delete(size_t attackerIndex, bool bForced, ATTACKER_CLEAR_T
 		if (tRet == TRIGRET_RET_TRUE)
 			return false;
 	}
-	std::vector<LastAttackers>::iterator it = m_lastAttackers.begin() + attackerIndex;
 
+	std::vector<LastAttackers>::iterator it = m_lastAttackers.begin() + attackerIndex;
 	m_lastAttackers.erase(it);
+
 	if (m_Fight_Targ_UID == pChar->GetUID())
 	{
 		m_Fight_Targ_UID.InitUID();
 		if (m_pNPC)
 			Fight_Attack(NPC_FightFindBestTarget());
 	}
-	if (!m_lastAttackers.size())
+	if (m_lastAttackers.empty())
+		Attacker_Clear();
+	return true;
+}
+
+// Removing attacker pointed by iterator
+bool CChar::Attacker_Delete(std::vector<LastAttackers>::iterator &itAttacker, bool bForced, ATTACKER_CLEAR_TYPE type)
+{
+	ADDTOCALLSTACK("CChar::Attacker_Delete(iterator)");
+	if (m_lastAttackers.empty())
+		return false;
+
+	CChar *pChar = static_cast<CUID>(itAttacker->charUID).CharFind();
+	if (!pChar)
+		return false;
+
+	if (IsTrigUsed(TRIGGER_COMBATDELETE))
+	{
+		CScriptTriggerArgs Args;
+		Args.m_iN1 = bForced;
+		Args.m_iN2 = static_cast<int>(type);
+		TRIGRET_TYPE tRet = OnTrigger(CTRIG_CombatDelete, pChar, &Args);
+		if (tRet == TRIGRET_RET_TRUE)
+			return false;
+	}
+
+	itAttacker = m_lastAttackers.erase(itAttacker);		// update the iterator to prevent invalidation and crashes!
+
+	if (m_Fight_Targ_UID == pChar->GetUID())
+	{
+		m_Fight_Targ_UID.InitUID();
+		if (m_pNPC)
+			Fight_Attack(NPC_FightFindBestTarget());
+	}
+	if (m_lastAttackers.empty())
 		Attacker_Clear();
 	return true;
 }
@@ -340,7 +376,7 @@ bool CChar::Attacker_Delete(CChar * pChar, bool bForced, ATTACKER_CLEAR_TYPE typ
 	ADDTOCALLSTACK("CChar::Attacker_Delete(CChar)");
 	if ( !pChar )
 		return false;
-	if ( ! m_lastAttackers.size() )
+	if ( m_lastAttackers.empty() )
 		return false;
 	return Attacker_Delete( Attacker_GetID(pChar), bForced, type );
 }
@@ -349,15 +385,15 @@ bool CChar::Attacker_Delete(CChar * pChar, bool bForced, ATTACKER_CLEAR_TYPE typ
 void CChar::Attacker_RemoveChar()
 {
 	ADDTOCALLSTACK("CChar::Attacker_RemoveChar");
-	if ( m_lastAttackers.size() )
+	if ( !m_lastAttackers.empty() )
 	{
-		for ( size_t count = 0 ; count < m_lastAttackers.size(); count++)
+		for (auto it = m_lastAttackers.begin(), end = m_lastAttackers.end(); it != end; ++it)
 		{
-			LastAttackers & refAttacker = m_lastAttackers.at(count);
+			LastAttackers & refAttacker = *it;
 			CChar * pSrc = static_cast<CUID>(refAttacker.charUID).CharFind();
 			if ( !pSrc )
 				continue;
-			pSrc->Attacker_Delete(pSrc->Attacker_GetID(this), false, ATTACKER_CLEAR_REMOVEDCHAR);
+			pSrc->Attacker_Delete(it, false, ATTACKER_CLEAR_REMOVEDCHAR);
 		}
 	}
 }
@@ -366,20 +402,21 @@ void CChar::Attacker_RemoveChar()
 void CChar::Attacker_CheckTimeout()
 {
 	ADDTOCALLSTACK("CChar::Attacker_CheckTimeout");
-	if (m_lastAttackers.size() > 0)
+	if (!m_lastAttackers.empty())
 	{
-		for (size_t count = 0; count < m_lastAttackers.size(); count++)
+		size_t count = 0;
+		for (auto it = m_lastAttackers.begin(), end = m_lastAttackers.end(); it != end; ++it)
 		{
-			LastAttackers & refAttacker = m_lastAttackers.at(count);
+			LastAttackers & refAttacker = *it;
 			CChar *pEnemy = static_cast<CUID>(refAttacker.charUID).CharFind();
 			if ( pEnemy && ( ++(refAttacker.elapsed) > g_Cfg.m_iAttackerTimeout ) && (g_Cfg.m_iAttackerTimeout > 0) )
 			{
 				DEBUG_MSG(("AttackerTimeout elapsed for char '%s' (UID: 0%" PRIx32 "): "
 					"deleted attacker '%s' (index: %d, UID: 0%" PRIx32 ")\n",
 					GetName(), GetUID().GetObjUID(), pEnemy->GetName(), count, pEnemy->GetUID().GetObjUID() ));
-				Attacker_Delete(count, true, ATTACKER_CLEAR_ELAPSED);
+				Attacker_Delete(it, true, ATTACKER_CLEAR_ELAPSED);
 			}
-				
+			++count;				
 		}
 	}
 }

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -938,7 +938,7 @@ effect_bounce:
 	{
 		// Update attacker list
 		bool bAttackerExists = false;
-		for (std::vector<LastAttackers>::iterator it = m_lastAttackers.begin(); it != m_lastAttackers.end(); ++it)
+		for (std::vector<LastAttackers>::iterator it = m_lastAttackers.begin(), end = m_lastAttackers.end(); it != end; ++it)
 		{
 			LastAttackers & refAttacker = *it;
 			if ( refAttacker.charUID == pSrc->GetUID().GetPrivateUID() )

--- a/src/game/chars/CCharNPCAct.cpp
+++ b/src/game/chars/CCharNPCAct.cpp
@@ -1049,13 +1049,6 @@ bool CChar::NPC_LookAround( bool fForceCheckItems )
 	if ( !m_pNPC || !pSector )
 		return false;
 
-	if ( !IsPlayableCharacter() && ( (m_pNPC->m_Brain == NPCBRAIN_BERSERK) || !Calc_GetRandVal(6) ) )
-	{
-		// Make some random noise, unrelated to the action (if action related, use CRESND_TYPE and SoundChar)
-		SOUND_TYPE snd = GetDefaultSound();
-		Sound(Calc_GetRandVal(2) ? snd : (SOUND_TYPE)(snd+1));
-	}
-
 	int iRange = GetSight();
 	int iRangeBlur = UO_MAP_VIEW_SIGHT;
 
@@ -1075,6 +1068,7 @@ bool CChar::NPC_LookAround( bool fForceCheckItems )
 			m_Act_p = GetTopPoint();
 			m_Act_p.Move(static_cast<DIR_TYPE>(Calc_GetRandVal(DIR_QTY)));
 			NPC_WalkToPoint(true);
+			SoundChar(CRESND_NOTICE);
 			return true;
 		}
 
@@ -1105,7 +1099,10 @@ bool CChar::NPC_LookAround( bool fForceCheckItems )
 				continue;	// can't see them.
 		}
 		if ( NPC_LookAtChar(pChar, iDist) )
+		{
+			SoundChar(CRESND_NOTICE);
 			return true;
+		}
 	}
 
 	// Check the ground for good stuff.
@@ -1129,9 +1126,15 @@ bool CChar::NPC_LookAround( bool fForceCheckItems )
 					continue;	// can't see them.
 			}
 			if ( NPC_LookAtItem(pItem, iDist) )
+			{
+				SoundChar(CRESND_NOTICE);
 				return true;
+			}
 		}
 	}
+
+	if ( !IsPlayableCharacter() && ( (m_pNPC->m_Brain == NPCBRAIN_BERSERK) || !Calc_GetRandVal(6) ) )
+		SoundChar(CRESND_IDLE);
 
 	// Move stuff that is in our way ? (chests etc.)
 	return false;

--- a/src/game/chars/CCharNPCAct_Fight.cpp
+++ b/src/game/chars/CCharNPCAct_Fight.cpp
@@ -62,7 +62,7 @@ CChar * CChar::NPC_FightFindBestTarget()
 
 	if ( Attacker() )
 	{
-		if ( !m_lastAttackers.size() )
+		if ( m_lastAttackers.empty() )
 			return NULL;
 
 		int64 threat = 0;
@@ -71,7 +71,7 @@ CChar * CChar::NPC_FightFindBestTarget()
 		CChar *pClosest = NULL;
 		SKILL_TYPE skillWeapon = Fight_GetWeaponSkill();
 
-        for (std::vector<LastAttackers>::iterator it = m_lastAttackers.begin(); it != m_lastAttackers.end(); ++it)
+        for (std::vector<LastAttackers>::iterator it = m_lastAttackers.begin(), end = m_lastAttackers.end(); it != end; ++it)
 		{
 			LastAttackers &refAttacker = *it;
 			pChar = static_cast<CChar*>(static_cast<CUID>(refAttacker.charUID).CharFind());
@@ -104,13 +104,13 @@ CChar * CChar::NPC_FightFindBestTarget()
 			int iDist = GetDist(pChar);
             if (iDist > UO_MAP_VIEW_SIGHT)
             {
-                Attacker_Delete(pChar, false, ATTACKER_CLEAR_DISTANCE);
+                Attacker_Delete(it, false, ATTACKER_CLEAR_DISTANCE);
 				pChar = NULL;
-                if (m_lastAttackers.size() <= 0)
+                if (m_lastAttackers.empty())
                     break;
                 continue;
             }
-			if ( g_Cfg.IsSkillFlag(skillWeapon, SKF_RANGED) && (iDist < g_Cfg.m_iArcheryMinDist || iDist > g_Cfg.m_iArcheryMaxDist) )
+			if ( g_Cfg.IsSkillFlag(skillWeapon, SKF_RANGED) && ((iDist < g_Cfg.m_iArcheryMinDist) || (iDist > g_Cfg.m_iArcheryMaxDist)) )
 				continue;
 			if ( !CanSeeLOS(pChar) )
 				continue;

--- a/src/game/chars/CCharNPCPet.cpp
+++ b/src/game/chars/CCharNPCPet.cpp
@@ -24,10 +24,7 @@ void CChar::NPC_OnPetCommand( bool fSuccess, CChar * pMaster )
 	if ( NPC_CanSpeak() )
 		Speak( fSuccess ? g_Cfg.GetDefaultMsg( DEFMSG_NPC_PET_SUCCESS ) : g_Cfg.GetDefaultMsg( DEFMSG_NPC_PET_FAILURE ) );
 	else
-	{
-		SOUND_TYPE snd = GetDefaultSound();
-		Sound( fSuccess ? snd : (SOUND_TYPE)(snd + 1) );	// random sound
-	}
+		SoundChar( fSuccess ? CRESND_NOTICE : CRESND_IDLE );
 }
 
 enum PC_TYPE
@@ -211,7 +208,7 @@ bool CChar::NPC_OnHearPetCmd( lpctstr pszCmd, CChar *pSrc, bool fAllPets )
 			break;
 
 		case PC_RELEASE:
-			SoundChar(CRESND_RAND2);
+			SoundChar(CRESND_RAND);
 			if ( IsStatFlag(STATF_Conjured) || (m_pNPC->m_bonded && IsStatFlag(STATF_DEAD)) )
 			{
 				Delete();

--- a/src/game/chars/CCharStatus.cpp
+++ b/src/game/chars/CCharStatus.cpp
@@ -938,16 +938,6 @@ lpctstr CChar::GetTradeTitle() const // Paperdoll title for character p (2)
 	return pTemp;
 }
 
-SOUND_TYPE CChar::GetDefaultSound() const
-{
-	ADDTOCALLSTACK_INTENSIVE("CChar::GetDefaultSound");
-	const CCharBase* pBase = Char_GetDef();
-	if (pBase->m_soundbase)
-		return (CRESND_TYPE)pBase->m_soundbase;
-	DEBUG_MSG(("CHARDEF %s has no SOUND!\n", GetResourceName()));
-	return (SOUND_TYPE)0;
-}
-
 bool CChar::CanDisturb( const CChar *pChar ) const
 {
 	ADDTOCALLSTACK_INTENSIVE("CChar::CanDisturb");

--- a/src/game/chars/CCharUse.cpp
+++ b/src/game/chars/CCharUse.cpp
@@ -1109,7 +1109,7 @@ CChar * CChar::Use_Figurine( CItem * pItem, bool bCheckFollowerSlots )
 	pPet->MoveToChar(pItem->GetTopLevelObj()->GetTopPoint());
 	pPet->Update();
 	pPet->Skill_Start(SKILL_NONE);	// was NPCACT_RIDDEN
-	pPet->Sound(pPet->GetDefaultSound());
+	pPet->SoundChar(CRESND_IDLE);
 	return pPet;
 }
 

--- a/src/game/chars/CCharact.cpp
+++ b/src/game/chars/CCharact.cpp
@@ -1398,93 +1398,15 @@ void CChar::SoundChar( CRESND_TYPE type )
 	if ( !g_Cfg.m_fGenericSounds )
 		return;
 
-	SOUND_TYPE id;
-
-	CCharBase* pCharDef = Char_GetDef();
-	switch ( GetDispID() )
+	if ((type < CRESND_RAND) || (type > CRESND_DIE))
 	{
-		case CREID_BLADES:
-			id = pCharDef->m_soundbase;
-			break;
-
-		case CREID_MAN:
-		case CREID_WOMAN:
-		case CREID_GHOSTMAN:
-		case CREID_GHOSTWOMAN:
-		case CREID_ELFMAN:
-		case CREID_ELFWOMAN:
-		case CREID_ELFGHOSTMAN:
-		case CREID_ELFGHOSTWOMAN:
-		case CREID_GARGMAN:
-		case CREID_GARGWOMAN:
-		case CREID_GARGGHOSTMAN:
-		case CREID_GARGGHOSTWOMAN:
-		{
-			id = 0;
-
-			static const SOUND_TYPE sm_Snd_Man_Die[] = { 0x15a, 0x15b, 0x15c, 0x15d };
-			static const SOUND_TYPE sm_Snd_Man_Omf[] = { 0x154, 0x155, 0x156, 0x157, 0x158, 0x159 };
-			static const SOUND_TYPE sm_Snd_Wom_Die[] = { 0x150, 0x151, 0x152, 0x153 };
-			static const SOUND_TYPE sm_Snd_Wom_Omf[] = { 0x14b, 0x14c, 0x14d, 0x14e, 0x14f };
-
-			if ( pCharDef->IsFemale())
-			{
-				switch ( type )
-				{
-					case CRESND_GETHIT:
-						id = sm_Snd_Wom_Omf[ Calc_GetRandVal( CountOf(sm_Snd_Wom_Omf)) ];
-						break;
-					case CRESND_DIE:
-						id = sm_Snd_Wom_Die[ Calc_GetRandVal( CountOf(sm_Snd_Wom_Die)) ];
-						break;
-					default:
-						break;
-				}
-			}
-			else
-			{
-				switch ( type )
-				{
-					case CRESND_GETHIT:
-						id = sm_Snd_Man_Omf[ Calc_GetRandVal( CountOf(sm_Snd_Man_Omf)) ];
-						break;
-					case CRESND_DIE:
-						id = sm_Snd_Man_Die[ Calc_GetRandVal( CountOf(sm_Snd_Man_Die)) ];
-						break;
-					default:
-						break;
-				}
-			}
-		} break;
-
-		default:
-		{
-			id = static_cast<SOUND_TYPE>(pCharDef->m_soundbase + type);
-			switch ( pCharDef->m_soundbase )	// some creatures have no base sounds.
-			{
-				case 0:
-					id = SOUND_NONE;
-					break;
-				case 128: // old versions
-				case 181:
-				case 199:
-					if ( type <= CRESND_RAND2 )
-						id = SOUND_NONE;
-					break;
-				case 130: // ANIMALS_DEER3
-				case 183: // ANIMALS_LLAMA3
-				case 201: // ANIMALS_RABBIT3
-					if ( type <= CRESND_RAND2 )
-						id = SOUND_NONE;
-					else
-						id = static_cast<SOUND_TYPE>(id-2);
-					break;
-				default:
-					break;
-			}
-		} break;
+		DEBUG_WARN(("Invalid SoundChar type: %d.\n", (int)type));
+		return;
 	}
 
+	SOUND_TYPE id = SOUND_NONE;
+
+	// Am i hitting with a weapon?
 	if ( type == CRESND_HIT )
 	{
 		CItem * pWeapon = m_uidWeapon.ItemFind();
@@ -1494,7 +1416,7 @@ void CChar::SoundChar( CRESND_TYPE type )
 			if ( pVar )
 			{
 				if ( pVar->GetValNum() )
-					id = static_cast<SOUND_TYPE>(pVar->GetValNum());
+					id = (SOUND_TYPE)(pVar->GetValNum());
 			}
 			else
 			{
@@ -1512,7 +1434,6 @@ void CChar::SoundChar( CRESND_TYPE type )
 						// 0x232 = axe01 swing. (miss?)
 						id = 0x232;
 						break;
-					case IT_WEAPON_THROWING:
 					case IT_WEAPON_SWORD:
 					case IT_WEAPON_AXE:
 						if ( pWeapon->Item_GetDef()->GetEquipLayer() == LAYER_HAND2 )
@@ -1522,6 +1443,7 @@ void CChar::SoundChar( CRESND_TYPE type )
 							id = Calc_GetRandVal( 2 ) ? 0x236 : 0x237;
 							break;
 						}
+						// if not two handed, don't break, just fall through and use the same sound ID as a fencing weapon
 					case IT_WEAPON_FENCE:
 						// 0x23b = sword1
 						// 0x23c = sword7
@@ -1532,25 +1454,188 @@ void CChar::SoundChar( CRESND_TYPE type )
 						// 0x234 = xbow (hit)
 						id = 0x234;
 						break;
+					case IT_WEAPON_THROWING:
+						// 0x5D2 = throwH
+						id = 0x5D2;
+						break;
 					default:
 						break;
 				}
 			}
 
 		}
-		else if ( id == 0 )
+	}
+	
+	if ( id == SOUND_NONE )	// i'm not hitting with a weapon
+	{
+		const CCharBase* pCharDef = Char_GetDef();
+		switch ( GetDispID() )
 		{
-			static const SOUND_TYPE sm_Snd_Hit[] =
+			// Special creatures
+			case CREID_BLADES:
+				id = pCharDef->m_soundbase;
+				if (!Calc_GetRandVal(2))
+					++id;
+				break;
+
+			// Every other creature
+			default:
 			{
-				0x135,	//= hit01 = (slap)
-				0x137,	//= hit03 = (hit sand)
-				0x13b	//= hit07 = (hit slap)
-			};
-			id = sm_Snd_Hit[ Calc_GetRandVal( CountOf( sm_Snd_Hit )) ];
+				id = pCharDef->m_soundbase;
+				if (type == CRESND_RAND)
+					type = Calc_GetRandVal(2) ? CRESND_IDLE : CRESND_NOTICE;		// pick randomly CRESND_IDLE or CRESND_NOTICE
+
+				switch ( id )	
+				{
+					case 0:		// some creatures have no base sounds, in this case i shouldn't attempt to play them.
+						id = SOUND_NONE;
+						DEBUG_MSG(("CHARDEF %s has no base SOUND!\n", GetResourceName()));
+						break;
+
+					// SOUND values used in old scripts?
+					case 128:	// 0x80: crow3
+					case 181:	// 0xb5: lion3
+					case 199:	// 0xc7: pig3
+						id -= (SOUND_TYPE)2;
+						break;
+
+					// Creatures that have only 3 types of sound (hit, gethit, die).
+					case 130: // snd_ANIMALS_DEER3
+					case 183: // snd_ANIMALS_LLAMA3
+					case 201: // snd_ANIMALS_RABBIT3
+					case 702: // another deer
+						if (type < CRESND_HIT)
+						{
+							id = SOUND_NONE;
+							break;
+						}
+						id -= 2;
+						break;
+
+					case 1127: // snd_MONSTER_PIXIE1
+					case 1134: // snd_MONSTER_PIXIE2_1
+						switch (type)
+						{
+							case CRESND_IDLE:	id += (SOUND_TYPE)5;	break;
+							case CRESND_NOTICE:	id += (SOUND_TYPE)3;	break;
+							case CRESND_HIT:							break;
+							case CRESND_GETHIT:	id += (SOUND_TYPE)4;	break;
+							case CRESND_DIE:	id += (SOUND_TYPE)2;	break;
+							default: break;
+						}
+						break;
+					case 1541: // snd_monster_homunculous1
+						break;	// homunculous has only 1 sound.
+					case SOUND_SPECIAL_MONSTER_JUKA:
+						switch (type)
+						{
+							case CRESND_IDLE:	id = (SOUND_TYPE)0/*0x1AC*/;	break;
+							case CRESND_NOTICE:	id = (SOUND_TYPE)0/*0x1CD*/;	break;
+							case CRESND_HIT:	id = (SOUND_TYPE)0x1B0;	break;
+							case CRESND_GETHIT:	id = (SOUND_TYPE)0x1D0;	break;
+							case CRESND_DIE:	id = (SOUND_TYPE)0x28D;	break;
+							default: break;
+						}
+						break;
+					case SOUND_SPECIAL_MONSTER_MEER:
+						switch (type)
+						{
+							case CRESND_IDLE:	id = (SOUND_TYPE)0;	break;
+							case CRESND_NOTICE:	id = (SOUND_TYPE)0;	break;
+							case CRESND_HIT:	id = (SOUND_TYPE)0x28B;	break;
+							case CRESND_GETHIT:	id = (SOUND_TYPE)0x167;	break;
+							case CRESND_DIE:	id = (SOUND_TYPE)0xBC;	break;
+							default: break;
+						}
+						break;
+					case SOUND_SPECIAL_MONSTER_EXODUSMINION:
+						switch (type)
+						{
+							case CRESND_IDLE:	id = (SOUND_TYPE)0xFD;	break;
+							case CRESND_NOTICE:	id = (SOUND_TYPE)0x26C;	break;
+							case CRESND_HIT:	id = (SOUND_TYPE)0x23B;	break;
+							case CRESND_GETHIT:	id = (SOUND_TYPE)0x140;	break;
+							case CRESND_DIE:	id = (SOUND_TYPE)0x211;	break;
+							default: break;
+						}
+						break;
+
+					case SOUND_SPECIAL_HUMAN:
+					{
+						static const SOUND_TYPE sm_Snd_Hit[] =
+						{
+							0x135,	//= hit01 = (slap)
+							0x137,	//= hit03 = (hit sand)
+							0x13b	//= hit07 = (hit slap)
+						};
+						static const SOUND_TYPE sm_Snd_Man_Die[] = { 0x15a, 0x15b, 0x15c, 0x15d };
+						static const SOUND_TYPE sm_Snd_Man_Omf[] = { 0x154, 0x155, 0x156, 0x157, 0x158, 0x159 };
+						static const SOUND_TYPE sm_Snd_Wom_Die[] = { 0x150, 0x151, 0x152, 0x153 };
+						static const SOUND_TYPE sm_Snd_Wom_Omf[] = { 0x14b, 0x14c, 0x14d, 0x14e, 0x14f };
+
+						if (type == CRESND_HIT)
+						{
+							id = sm_Snd_Hit[ Calc_GetRandVal( CountOf( sm_Snd_Hit )) ];		// same sound for every race and sex
+						}
+						else if ( pCharDef->IsFemale() )
+						{
+							switch ( type )
+							{
+								case CRESND_GETHIT:	id = sm_Snd_Wom_Omf[ Calc_GetRandVal( CountOf(sm_Snd_Wom_Omf)) ];	break;
+								case CRESND_DIE:	id = sm_Snd_Wom_Die[ Calc_GetRandVal( CountOf(sm_Snd_Wom_Die)) ];	break;
+								default:	break;
+							}
+						}
+						else	// not CRESND_HIT and male character
+						{
+							switch ( type )
+							{
+								case CRESND_GETHIT:	id = sm_Snd_Man_Omf[ Calc_GetRandVal( CountOf(sm_Snd_Man_Omf)) ];	break;
+								case CRESND_DIE:	id = sm_Snd_Man_Die[ Calc_GetRandVal( CountOf(sm_Snd_Man_Die)) ];	break;
+								default:	break;
+							}
+						}
+					}
+					// No idle/notice sounds for this.
+					break;
+
+					// Every other sound
+					default:
+						if (id < 0x4D6)			// before the crane sound the sound IDs are ordered in a way...
+							id += (SOUND_TYPE)type;
+						else if (id < 0x5D5)	// starting with the crane and ending before absymal infernal there's another scheme
+						{
+							switch (type)
+							{
+								case CRESND_IDLE:	id += (SOUND_TYPE)2;	break;
+								case CRESND_NOTICE:	id += (SOUND_TYPE)3;	break;
+								case CRESND_HIT:	id += (SOUND_TYPE)1;	break;
+								case CRESND_GETHIT:	id += (SOUND_TYPE)4;	break;
+								case CRESND_DIE:							break;
+								default: break;
+							}
+						}
+						else					// staring with absymal infernal there's another scheme (and they have 4 sounds instead of 5)
+						{
+							switch (type)
+							{
+								case CRESND_IDLE:	id += (SOUND_TYPE)3;	break;
+								case CRESND_NOTICE:	id += (SOUND_TYPE)3;	break;
+								case CRESND_HIT:							break;
+								case CRESND_GETHIT:	id += (SOUND_TYPE)2;	break;
+								case CRESND_DIE:	id += (SOUND_TYPE)1;	break;
+								default: break;
+							}
+						}
+						break;
+				}
+			}
+			break;
 		}
 	}
 
-	Sound(id);
+	if (id != SOUND_NONE)
+		Sound(id);
 }
 
 // Pickup off the ground or remove my own equipment. etc..
@@ -2281,7 +2366,7 @@ CItem * CChar::Make_Figurine( CUID uidOwner, ITEMID_TYPE id )
 	if ( IsStatFlag(STATF_Insubstantial) )
 		pItem->SetAttr(ATTR_INVIS);
 
-	Sound(GetDefaultSound());			// Horse winny
+	SoundChar(CRESND_IDLE);			// Horse winny
 	StatFlag_Set(STATF_Ridden);
 	Skill_Start(NPCACT_RIDDEN);
 	SetDisconnected();
@@ -3902,7 +3987,7 @@ void CChar::OnTickFood(short iVal, int HitsHungerLoss)
 	if ( iFoodLevel <= 0 )
 	{
 		OnTakeDamage(HitsHungerLoss, this, DAMAGE_FIXED);
-		SoundChar(CRESND_RAND2);
+		SoundChar(CRESND_RAND);
 		if ( bPet )
 			NPC_PetDesert();
 	}

--- a/src/game/clients/CAccount.cpp
+++ b/src/game/clients/CAccount.cpp
@@ -854,7 +854,7 @@ void CAccount::ClearPasswordTries(bool bAll)
 	}
 
 	llong timeCurrent = CServerTime::GetCurrentTime().GetTimeRaw();
-	for ( BlockLocalTime_t::iterator itData = m_BlockIP.begin(); itData != m_BlockIP.end(); ++itData )
+	for ( BlockLocalTime_t::iterator itData = m_BlockIP.begin(), end = m_BlockIP.end(); itData != end; ++itData )
 	{
 		BlockLocalTimePair_t itResult = (*itData).second;
 		if ( (timeCurrent - itResult.first.m_Last) > g_Cfg.m_iClientLoginTempBan )

--- a/src/game/items/CItemMultiCustom.cpp
+++ b/src/game/items/CItemMultiCustom.cpp
@@ -111,7 +111,7 @@ void CItemMultiCustom::BeginCustomize(CClient * pClientSrc)
 
 	// client will silently close all open dialogs and let the server think they're still open, so we need to update opened gump counts here
 	CDialogDef* pDlg = NULL;
-	for (CClient::OpenedGumpsMap_t::iterator it = pClientSrc->m_mapOpenedGumps.begin(); it != pClientSrc->m_mapOpenedGumps.end(); ++it)
+	for (CClient::OpenedGumpsMap_t::iterator it = pClientSrc->m_mapOpenedGumps.begin(), end = pClientSrc->m_mapOpenedGumps.end(); it != end; ++it)
 	{
 		// the client leaves 'nodispose' dialogs open
 		pDlg = dynamic_cast<CDialogDef*>( g_Cfg.ResourceGetDef(CResourceID(RES_DIALOG, it->first)) );
@@ -1566,7 +1566,7 @@ bool CItemMultiCustom::LoadValidItems()
 
 	tchar* pszRowFull = Str_GetTemp();
 	tchar* pszHeaderFull = Str_GetTemp();
-	for ( CSVRowData::iterator itCsv = csvDataRow.begin(); itCsv != csvDataRow.end(); ++itCsv )
+	for ( CSVRowData::iterator itCsv = csvDataRow.begin(), end = csvDataRow.end(); itCsv != end; ++itCsv )
 	{
 		strcat(pszHeaderFull, "\t");
 		strcat(pszHeaderFull, itCsv->first.c_str());

--- a/src/game/uo_files/uofiles_enums.h
+++ b/src/game/uo_files/uofiles_enums.h
@@ -85,7 +85,7 @@ enum SOUND_CODE
     SOUND_FEET_PAVE_1	= 0x12f,	// on slate sound
     SOUND_FEET_PAVE_2	= 0x130,
 
-    SOUND_HIT_10		= 0x013e,
+    SOUND_HIT_10		= 0x13e,
 
     SOUND_GHOST_1		= 382,
     SOUND_GHOST_2,
@@ -97,8 +97,23 @@ enum SOUND_CODE
     SOUND_SWORD_7		= 0x023c,
 
     SOUND_SNIP			= 0x248,
+	SOUND_SCRIBE		= 0x249,
+	SOUND_SPIRITSPEAK	= 0x24A,
+	SOUND_CROSSBOW		= 0x2B1,
+	SOUND_DROP_MONEY1	= 0x2E4,
+	SOUND_DROP_MONEY2	= 0x2E5,
+	SOUND_DROP_MONEY3	= 0x2E6,
+	SOUND_GLASS_BREAK4	= 0x390,
 
-    SOUND_QTY			= 0x300
+    //SOUND_QTY			= 0x67F,
+
+	// Special sounds: they are internally converted to the right sound.
+	//	These are used because some creatures do not have sound IDs sequentially ordered in the sound file
+	//	(or they do not have a sound, so we mix different sounds).
+	SOUND_SPECIAL_HUMAN			= 0x900,
+	SOUND_SPECIAL_MONSTER_JUKA,
+	SOUND_SPECIAL_MONSTER_MEER,
+	SOUND_SPECIAL_MONSTER_EXODUSMINION
 };
 
 
@@ -246,8 +261,9 @@ enum ANIM_TYPE_NEW	// not all creatures animate the same for some reason. http:/
 
 enum CRESND_TYPE	// Placeholders (not real sound IDs): the SoundChar method chooses the best sound for each creature
 {
-    CRESND_RAND1,	// just random noise. or default "yes" response
-    CRESND_RAND2,	// just random noise. or default "no" response
+	CRESND_RAND		= -1,	// pick up randomly CRESND_IDLE or CRESND_NOTICE
+    CRESND_IDLE		= 0,	// just random noise. or default "no" response
+    CRESND_NOTICE,			// just random noise. or default "yes" response
     
 	CRESND_HIT,
     CRESND_GETHIT,

--- a/src/network/network_common.cpp
+++ b/src/network/network_common.cpp
@@ -507,12 +507,12 @@ void IPHistoryManager::tick(void)
 	if (decayTTL)
 		m_lastDecayTime = CServerTime::GetCurrentTime();
 
-	for (IPHistoryList::iterator it = m_ips.begin(); it != m_ips.end(); ++it)
+	for (IPHistoryList::iterator it = m_ips.begin(), end = m_ips.end(); it != end; ++it)
 	{
 		if (it->m_blocked)
 		{
 			// blocked ips don't decay, but check if the ban has expired
-			if (it->m_blockExpire.IsTimeValid() && CServerTime::GetCurrentTime() > it->m_blockExpire)
+			if (it->m_blockExpire.IsTimeValid() && (CServerTime::GetCurrentTime() > it->m_blockExpire))
 				it->setBlocked(false);
 		}
 		else if (decayTTL)
@@ -534,7 +534,7 @@ void IPHistoryManager::tick(void)
 	}
 
 	// clear old ip history
-	for (IPHistoryList::iterator it = m_ips.begin(); it != m_ips.end(); ++it)
+	for (IPHistoryList::iterator it = m_ips.begin(), end = m_ips.end(); it != end; ++it)
 	{
 		if (it->m_ttl >= 0)
 			continue;

--- a/src/network/network_multithreaded.cpp
+++ b/src/network/network_multithreaded.cpp
@@ -156,7 +156,7 @@ NetworkThread* NetworkManager::selectBestThread(void)
 	DEBUGNETWORK(("Searching for a suitable thread to handle a new client..\n"));
 
 	// search for quietest thread
-	for (NetworkThreadList::iterator it = m_threads.begin(); it != m_threads.end(); ++it)
+	for (NetworkThreadList::iterator it = m_threads.begin(), end = m_threads.end(); it != end; ++it)
 	{
 		if ((*it)->getClientCount() < bestThreadSize)
 		{
@@ -339,7 +339,7 @@ void NetworkManager::start(void)
 	if (isThreaded())
 	{
 		// start network threads
-		for (NetworkThreadList::iterator it = m_threads.begin(); it != m_threads.end(); ++it)
+		for (NetworkThreadList::iterator it = m_threads.begin(), end = m_threads.end(); it != end; ++it)
 			(*it)->start();
 
 		DEBUGNETWORK(("Started %" PRIuSIZE_T " network threads.\n", m_threads.size()));
@@ -347,7 +347,7 @@ void NetworkManager::start(void)
 	else
 	{
 		// initialise network threads
-		for (NetworkThreadList::iterator it = m_threads.begin(); it != m_threads.end(); ++it)
+		for (NetworkThreadList::iterator it = m_threads.begin(), end = m_threads.end(); it != end; ++it)
 			(*it)->onStart();
 	}
 }
@@ -355,7 +355,7 @@ void NetworkManager::start(void)
 void NetworkManager::stop(void)
 {
 	// terminate child threads
-	for (NetworkThreadList::iterator it = m_threads.begin(); it != m_threads.end(); ++it)
+	for (NetworkThreadList::iterator it = m_threads.begin(), end = m_threads.end(); it != end; ++it)
 		(*it)->waitForClose();
 }
 
@@ -426,7 +426,7 @@ void NetworkManager::tick(void)
 	m_ips.tick();
 
 	// tick child threads, if single-threaded mode
-	for (NetworkThreadList::iterator it = m_threads.begin(); it != m_threads.end(); ++it)
+	for (NetworkThreadList::iterator it = m_threads.begin(), end = m_threads.end(); it != end; ++it)
 	{
 		NetworkThread* thread = *it;
 		if (thread->isActive() == false)
@@ -446,7 +446,7 @@ void NetworkManager::processAllInput(void)
 		acceptNewConnection();
 
 	// force each thread to process input (NOT THREADSAFE)
-	for (NetworkThreadList::iterator it = m_threads.begin(); it != m_threads.end(); ++it)
+	for (NetworkThreadList::iterator it = m_threads.begin(), end = m_threads.end(); it != end; ++it)
 		(*it)->processInput();
 }
 
@@ -458,7 +458,7 @@ void NetworkManager::processAllOutput(void)
 	if (isOutputThreaded() == false)
 	{
 		// force each thread to process output (NOT THREADSAFE)
-		for (NetworkThreadList::iterator it = m_threads.begin(); it != m_threads.end(); ++it)
+		for (NetworkThreadList::iterator it = m_threads.begin(), end = m_threads.end(); it != end; ++it)
 			(*it)->processOutput();
 	}
 }
@@ -468,7 +468,7 @@ void NetworkManager::flushAllClients(void)
 	// flush data for every client
 	ADDTOCALLSTACK("NetworkManager::flushAllClients");
 
-	for (NetworkThreadList::iterator it = m_threads.begin(); it != m_threads.end(); ++it)
+	for (NetworkThreadList::iterator it = m_threads.begin(), end = m_threads.end(); it != end; ++it)
 		(*it)->flushAllClients();
 }
 

--- a/src/network/packet.cpp
+++ b/src/network/packet.cpp
@@ -1277,7 +1277,7 @@ SimplePacketTransaction::~SimplePacketTransaction(void)
  ***************************************************************************/
 ExtendedPacketTransaction::~ExtendedPacketTransaction(void)
 {
-	for (std::list<PacketSend*>::iterator it = m_packets.begin(); it != m_packets.end(); ++it)
+	for (std::list<PacketSend*>::iterator it = m_packets.begin(), end = m_packets.end(); it != end; ++it)
 		delete *it;
 
 	m_packets.clear();

--- a/src/network/send.cpp
+++ b/src/network/send.cpp
@@ -1206,7 +1206,7 @@ PacketItemContents::PacketItemContents(CClient* target, const CItemContainer* co
 	if (m_count > 0)
 	{
 		// send tooltips
-		for (auto it = items.begin(); it != items.end(); it++)
+		for (auto it = items.begin(), end = items.end(); it != end; ++it)
 			target->addAOSTooltip(*it, false, boIsShop);
 	}	
 }

--- a/src/sphere/containers.h
+++ b/src/sphere/containers.h
@@ -56,13 +56,8 @@ public:
 			return 0;
 
 		size_t toSkip = 1;
-		for ( const_iterator it = m_list.begin(); it != m_head && it != m_list.end(); ++it )
-		{
-			if ( it == m_list.end() )
-				break;
-
-			toSkip++;
-		}
+		for ( const_iterator it = m_list.begin(), end = m_list.end(); (it != m_head) && (it != end); ++it )
+			++toSkip;
 
 		return m_list.size() - toSkip;
 	}

--- a/src/sphere/threads.cpp
+++ b/src/sphere/threads.cpp
@@ -97,12 +97,12 @@ IThread * ThreadHolder::getThreadAt(size_t at)
 		return NULL;
 
 	SimpleThreadLock lock(m_mutex);
-	for ( spherethreadlist_t::const_iterator it = m_threads.begin(); it != m_threads.end(); ++it )
+	for ( spherethreadlist_t::const_iterator it = m_threads.begin(), end = m_threads.end(); it != end; ++it )
 	{
 		if ( at == 0 )
 			return *it;
 
-		at--;
+		--at;
 	}
 
 	return NULL;


### PR DESCRIPTION
- Fixed: when playing a sound from a character from Samurai Empire and later expansions, it was chosen the wrong sound ID for the given action. This is caused by the different	order of IDs in the sound file after that expansion. Also, updated the script pack (sphere_defs.scp and sphere_monsters.scp) with a lot of new and corrected old sounds. Still, some sounds are missing.
- Fixed: some rare combat-related crashes.
- Added: SOUNDTYPE_RAND, SOUNDTYPE_IDLE, SOUNDTYPE_NOTICE, SOUNDTYPE_HIT, SOUNDTYPE_GETHIT, SOUNDTYPE_DIE defs to the scripts. They are meant to be used with BARK, which has always accepted as parameter the sound type (even if the wiki at this day doesn't say so), not the sound ID (use SOUND for this).
- Updated: now when an NPC is looking around it can play different sounds depending on its AI choices. Also prevented human-sounding chars to play such noises.

Updated some of the code which uses iterators to be a little more performing.