### PR TITLE
Fixes for PreHit and combat animations delay.

### DIFF
--- a/Changelog-56d-Nightlies.txt
+++ b/Changelog-56d-Nightlies.txt
@@ -984,3 +984,16 @@ Redeed now creates the deed before calling the @Redeed trigger and the deed gets
 	the @Fail, @SkillFail, @Start, @SkillStart triggers to be fired at each hit.
 	- Fixed: NPCs doing extra AI actions (wandering, food, etc checks) after each hit in combat. This caused sometimes the current combat action to be resetted
 	and then forced again, erasing the NPC combat data, which ultimately results in the NPC hitting twice in a few tenths of seconds.
+
+13-06-2018, Nolok
+- Changed: reverted the combat animation to not being "smooth". Now by default the swing animation has a fixed duration of 1 second (minimum anim delay/duration possible) and then the char waits the recoil time
+	before being able to start again the combat swing. This is done to match OSI style. The "underground" work is different now and it is working in this way: first a timer is started to wait for
+	the recoil time	(ARGN1 in @HitTry). When the timer has ended, the combat swing animation starts, also the timer is started again, but to wait for the animation to end (anim and timer duration are equal to
+	LOCAL.AnimDelay in @HitTry, and the default value is 1 second). Ended this second timer, the damage is dealt (Issue #111).
+- Added: .ini CombatFlag COMBAT_ANIM_HIT_SMOOTH to enable the old smooth combat. There's no delay between hits (in @HitTry LOCAL.AnimDelay is = 0), but the swing animation duration
+	(ARGN1 in @HitTry) is in this case equal to the delay you should have waited before starting a new swing.
+- Fixed: COMBATF_PREHIT wasn't working correctly (Issue #113, #108).
+- Changed: .ini CombatFlag COMBAT_PREHIT_NORANGE renamed to COMBAT_SWING_NORANGE, to avoid confusion with COMBATF_PREHIT.
+- Added: LOCAL.Swing_NoRange to @HitCheck trigger. -1 force disables the Swing_NoRange behaviour for the current hit, 0 leaves it dependent to the COMBAT_SWING_NORANGE ini CombatFlag,
+	while 1 force enables the Swing_NoRange behaviour (Issue #112).
+- Added: RETURN -2 into @HitCheck trigger continues the execution of the default combat code. This is useful if you want to use @HitCheck to only change LOCAL.Swing_NoRange.

--- a/src/common/CScriptObj.cpp
+++ b/src/common/CScriptObj.cpp
@@ -833,7 +833,7 @@ bool CScriptObj::r_WriteVal( lpctstr pszKey, CSString &sVal, CTextConsole * pSrc
 			if ( *pszKey && (( *pszKey < '0' ) || ( *pszKey > '9' )) && *pszKey != '-' )
 				goto badcmd;
 
-			int64	min = 1000, max = INT64_MIN;
+			int64 min = 1000, max = INT64_MIN;
 
 			if ( *pszKey )
 			{

--- a/src/game/CResourceCalc.cpp
+++ b/src/game/CResourceCalc.cpp
@@ -28,7 +28,7 @@ int CServerConfig::Calc_MaxCarryWeight( const CChar * pChar ) const
 //********************************
 // Combat
 
-int CServerConfig::Calc_CombatAttackSpeed( CChar * pChar, CItem * pWeapon )
+int CServerConfig::Calc_CombatAttackSpeed( const CChar * pChar, const CItem * pWeapon ) const
 {
 	ADDTOCALLSTACK("CServerConfig::Calc_CombatAttackSpeed");
 	// Calculate the swing speed value on chars

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -1560,7 +1560,7 @@ public:
      *
      * @return  The calculated combat attack speed.
      */
-	int Calc_CombatAttackSpeed( CChar * pChar, CItem * pWeapon );
+	int Calc_CombatAttackSpeed( const CChar * pChar, const CItem * pWeapon ) const;
 
     /**
      * @fn  int CServerConfig::Calc_CombatChanceToHit( CChar * pChar, CChar * pCharTarg, SKILL_TYPE skill );

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -2214,7 +2214,7 @@ do_default:
 			}
 
 		case CHC_FIGHTRANGE: //RANGE is now writable so this is changed to FIGHTRANGE as readable only
-			sVal.FormatVal( CalcFightRange( m_uidWeapon.ItemFind() ) );
+			sVal.FormatVal( Fight_CalcRange( m_uidWeapon.ItemFind() ) );
 			return true;
 		case CHC_BLOODCOLOR:
 			sVal.FormatHex( m_wBloodHue );

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -247,8 +247,11 @@ public:
 		// SKILL_THROWING
 		struct
 		{
-			WAR_SWING_TYPE m_War_Swing_State;	// ACTARG1 = We are in the war mode swing.
-			dword m_iLastSwingDelay;			// ACTARG2 = Duration (in msecs) of the previous swing.
+			WAR_SWING_TYPE m_War_Swing_State;   // ACTARG1 = We are in the war mode swing.
+			int16 m_iRecoilDelay;		        // ACTARG2 & 0x0000FFFF = Duration (in tenth of secs) of the previous swing recoil time.
+            int16 m_iSwingAnimationDelay;       // ACTARG2 & 0xFFFF0000 = Duration (in tenth of secs) of the previous swing animation duration.
+            int16 m_iSwingAnimation;            // ACTARG3 & 0x0000FFFF = hit animation id.
+            int16 m_iSwingIgnoreLastHitTag;     // ACTARG3 & 0xFFFF0000. Internally used by PreHit. If == 1 (which happens only for the hit after the first instahit), for this hit TAG.LastHit delay checking will be ignored.
 		} m_atFight;
 
 		// SKILL_ENTICEMENT
@@ -952,8 +955,11 @@ public:
 
 private:
 	// Armor, weapons and combat ------------------------------------
-	int	CalcFightRange( CItem * pWeapon = NULL );
-
+	int	Fight_CalcRange( CItem * pWeapon = nullptr ) const;
+    // 1.0 seconds is the minimum animation duration ("delay"), but we have to subtract the tenths of seconds that will pass until the next tick, since
+    //  the timer will start on the next tick
+    #define COMBAT_MIN_SWING_ANIMATION_DELAY (10 - (TICK_PER_SEC/10))
+    void Fight_SetDefaultSwingDelays();
 	
 	bool Fight_IsActive() const;
 public:
@@ -969,8 +975,9 @@ public:
 	void Fight_HitTry();
 	WAR_SWING_TYPE Fight_Hit( CChar * pCharTarg );
 	bool Fight_Parry(CItem * &pItemParry);
-	WAR_SWING_TYPE Fight_CanHit(CChar * pCharTarg);
+	WAR_SWING_TYPE Fight_CanHit(CChar * pCharTarg, bool fIgnoreDistance = false);
 	SKILL_TYPE Fight_GetWeaponSkill() const;
+    DAMAGE_TYPE Fight_GetWeaponDamType(const CItem* pWeapon = nullptr) const;
 	int Fight_CalcDamage( const CItem * pWeapon, bool bNoRandom = false, bool bGetMax = true ) const;
 	bool Fight_IsAttackable();
 

--- a/src/game/chars/CCharNPCAct_Fight.cpp
+++ b/src/game/chars/CCharNPCAct_Fight.cpp
@@ -325,7 +325,7 @@ void CChar::NPC_Act_Fight()
     }
 
     // Move in for melee type combat.
-    int iRange = CalcFightRange(m_uidWeapon.ItemFind());
+    int iRange = Fight_CalcRange(m_uidWeapon.ItemFind());
     //if ((iDist > iRange) || !CanSeeLOS(pChar))
     //{
         NPC_Act_Follow(false, iRange, false);

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -2668,16 +2668,7 @@ int CChar::Skill_Fighting( SKTRIG_TYPE stage )
 	if ( stage == SKTRIG_START )
 	{
 		m_atFight.m_War_Swing_State = WAR_SWING_EQUIPPING;
-
-		/*The following 4 lines should fix an exploit related to combat, but because they cause problem with
-		combat swings timer and we don't know what the exploit is I have commented them.
-		int64 iRemainingDelay = g_World.GetCurrentTime().GetTimeRaw() - m_atFight.m_timeNextCombatSwing;
-		if (iRemainingDelay < 0 || iRemainingDelay > 255)
-			iRemainingDelay = 0;
-		SetTimeout(iRemainingDelay);
-		*/
-
-		SetTimeout(0);
+        Fight_HitTry();	// this cleans up itself, executes the code related to the current m_War_Swing_State and sets the needed timers.
 		return g_Cfg.Calc_CombatChanceToHit(this, m_Fight_Targ_UID.CharFind());	// How difficult? 1-10000
 	}
 
@@ -2685,22 +2676,27 @@ int CChar::Skill_Fighting( SKTRIG_TYPE stage )
 	{
 		// Hit or miss my current target.
 		if ( !IsStatFlag(STATF_WAR) )
+        {
 			return -SKTRIG_ABORT;
+        }
 
-		if ( m_atFight.m_War_Swing_State != WAR_SWING_SWINGING )
-			m_atFight.m_War_Swing_State = WAR_SWING_READY;  // Waited my recoil time. So I'm ready.
+		Fight_HitTry();	// this cleans up itself, executes the code related to the current m_War_Swing_State and sets the needed timers.
 
-        //m_Act_Difficulty = g_Cfg.Calc_CombatChanceToHit(this, m_Fight_Targ_UID.CharFind()); // calculate the chance at every hit
-        //if ( !Skill_CheckSuccess(Skill_GetActive(), m_Act_Difficulty, false) )
-        //    m_Act_Difficulty = -m_Act_Difficulty;	// will result in failure
-
-		Fight_HitTry();	// this cleans up itself.
+        //if (m_atFight.m_War_Swing_State == WAR_SWING_EQUIPPING)
+        //{
+        //  m_Act_Difficulty = g_Cfg.Calc_CombatChanceToHit(this, m_Fight_Targ_UID.CharFind()); // calculate the chance at every hit
+        //  if ( !Skill_CheckSuccess(Skill_GetActive(), m_Act_Difficulty, false) )
+        //      m_Act_Difficulty = -m_Act_Difficulty;	// will result in failure
+        //}
 		return -SKTRIG_STROKE;	// Stay in the skill till we hit.
 	}
 
     if (stage == SKTRIG_FAIL)
     {
-        m_atFight.m_iLastSwingDelay = 0;
+        m_atFight.m_iRecoilDelay = 0;
+        m_atFight.m_iSwingAnimationDelay = 0;
+        m_atFight.m_iSwingAnimation = 0;
+        m_atFight.m_iSwingIgnoreLastHitTag = 0;
     }
 
 	return -SKTRIG_QTY;

--- a/src/game/game_enums.h
+++ b/src/game/game_enums.h
@@ -134,7 +134,8 @@ enum COMBATFLAGS_TYPE
     COMBAT_STACKARMOR           = 0x1000,   // if a region is covered by more than one armor part, all AR will count
     COMBAT_NOPOISONHIT          = 0x2000,   // Disables old (55i like) poisoning style: Poisoning > 30.0 && (RAND(100.0)> Poisoning) for monsters OR weapon.morez && (RAND(100) < weapon.morez ) for poisoned weapons.
     COMBAT_SLAYER               = 0x4000,    // Enables Slayer damage on PVM combat.
-    COMBAT_PREHIT_NORANGE       = 0x8000
+    COMBAT_SWING_NORANGE       = 0x8000,
+    COMBAT_ANIM_HIT_SMOOTH      = 0x10000
 };
 
 

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -323,10 +323,10 @@ WoolGrowthTime=30
 // Suppress player speech with 75% of capital letters
 SuppressCapitals=0
 
-// Extra combat flags to control the fight (default:0, 0.55i compatible)
+// Extra combat flags to control the fight (default: 0, 0.55i compatible)
 // COMBAT_NODIRCHANGE           00001 // Not rotate player when fighting (like was in 0.51a)
 // COMBAT_FACECOMBAT            00002 // Allow faced combat only (recommended)
-// COMBAT_PREHIT                00004 // The first hit in a fight is instant (delay 0.1 sec)
+// COMBAT_PREHIT                00004 // The first hit in a fight doesn't wait for the recoil time (like OSI) and the hit is landed only after the swing animation length (1.0 sec)
 // COMBAT_ELEMENTAL_ENGINE      00008 // Use DAM*/RES* to split damage/resist into Physical/Fire/Cold/Poison/Energy (AOS) instead use old AR (pre-AOS)
 // COMBAT_DCLICKSELF_UNMOUNTS   00020 // Unmount horse when dclicking self while in warmode
 // COMBAT_ALLOWHITFROMSHIP      00040 // Allow attacking opponents from ships
@@ -334,8 +334,10 @@ SuppressCapitals=0
 // COMBAT_STAYINRANGE           00200 // Abort attack swing when out of range instead of waiting to come back in range
 // COMBAT_STACKARMOR            01000 // If a region is covered by more than one armor part, all AR will count
 // COMBAT_NOPOISONHIT           02000 // Disables old (55i like) poisoning style (0~100% chance based on Poisoning skill for monsters, or 50% chance for poisoned weapons)
-// COMBAT_SLAYER				04000 // Enables Slayer damage PVM combat.
-// COMBAT_PREHIT_NORANGE        08000 // The swing can be started at distance and landed when in range.
+// COMBAT_SLAYER				04000 // Enables Slayer damage PVM combat
+// COMBAT_RECOIL_NORANGE		08000 // The hit can be started at distance, then the damage will be dealt when in range
+// COMBAT_ANIM_HIT_SMOOTH		010000 // The hit animation has the same duration as the swing delay, instead of having a fixed fast duration and being idle until the delay has expired.
+//									   //  WARNING: doesn't work with Gargoyles due to the new animation packet not accepting a custom animation duration!
 //CombatFlags=0
 
 // If COMBAT_ARCHERYCANMOVE is not enabled, wait this much tenth of seconds (minimum=0) after the player


### PR DESCRIPTION
- Changed: reverted the combat animation to not being "smooth". Now by default the swing animation has a fixed duration of 1 second (minimum anim delay/duration possible) and then the char waits the recoil time before being able to start again the combat swing. This is done to match OSI style. The "underground" work is different now and it is working in this way: first a timer is started to wait for the recoil time (ARGN1 in @HitTry). When the timer has ended, the combat swing animation starts, also the timer is started again, but to wait for the animation to end (anim and timer duration are equal to LOCAL.AnimDelay in @HitTry, and the default value is 1 second). Ended this second timer, the damage is dealt (Issue #111).
- Added: .ini CombatFlag COMBAT_ANIM_HIT_SMOOTH to enable the old smooth combat. There's no delay between hits (in @HitTry LOCAL.AnimDelay is = 0), but the swing animation duration (ARGN1 in @HitTry) is in this case equal to the delay you should have waited before starting a new swing.
- Fixed: COMBATF_PREHIT wasn't working correctly (Issue #113, #108).
- Changed: .ini CombatFlag COMBAT_PREHIT_NORANGE renamed to COMBAT_SWING_NORANGE, to avoid confusion with COMBATF_PREHIT.
- Added: LOCAL.Swing_NoRange to @HitCheck trigger. -1 force disables the Swing_NoRange behaviour for the current hit, 0 leaves it dependent to the COMBAT_SWING_NORANGE ini CombatFlag,	while 1 force enables the Swing_NoRange behaviour (Issue #112).
- Added: RETURN -2 into @HitCheck trigger continues the execution of the default combat code. This is useful if you want to use @HitCheck to only change LOCAL.Swing_NoRange.